### PR TITLE
Set proper Content-Length for responses with no content

### DIFF
--- a/Core/GenHTTP.Core/Protocol/ResponseHandler.cs
+++ b/Core/GenHTTP.Core/Protocol/ResponseHandler.cs
@@ -129,10 +129,8 @@ namespace GenHTTP.Core.Protocol
                 await WriteHeaderLine("Content-Encoding", response.ContentEncoding!).ConfigureAwait(false);
             }
 
-            if (response.ContentLength != null)
-            {
-                await WriteHeaderLine("Content-Length", response.ContentLength.ToString()).ConfigureAwait(false);
-            }
+            string contentLength = response.ContentLength != null ? response.ContentLength.ToString() : "0";
+            await WriteHeaderLine("Content-Length", contentLength).ConfigureAwait(false);
 
             if (response.Modified != null)
             {

--- a/Core/GenHTTP.Core/Protocol/ResponseHandler.cs
+++ b/Core/GenHTTP.Core/Protocol/ResponseHandler.cs
@@ -129,8 +129,21 @@ namespace GenHTTP.Core.Protocol
                 await WriteHeaderLine("Content-Encoding", response.ContentEncoding!).ConfigureAwait(false);
             }
 
-            string contentLength = response.ContentLength != null ? response.ContentLength.ToString() : "0";
-            await WriteHeaderLine("Content-Length", contentLength).ConfigureAwait(false);
+            if (response.ContentLength != null)
+            {
+                await WriteHeaderLine("Content-Length", response.ContentLength.ToString()).ConfigureAwait(false);
+            }
+            else
+            {
+                if (response.Content != null)
+                {
+                    await WriteHeaderLine("Transfer-Encoding", "chunked").ConfigureAwait(false);
+                }
+                else
+                {
+                    await WriteHeaderLine("Content-Length", "0").ConfigureAwait(false);
+                }
+            }
 
             if (response.Modified != null)
             {
@@ -140,11 +153,6 @@ namespace GenHTTP.Core.Protocol
             if (response.Expires != null)
             {
                 await WriteHeaderLine("Expires", (DateTime)response.Expires).ConfigureAwait(false);
-            }
-
-            if ((response.Content != null) && (response.ContentLength == null))
-            {
-                await WriteHeaderLine("Transfer-Encoding", "chunked").ConfigureAwait(false);
             }
 
             foreach (var header in response.Headers)


### PR DESCRIPTION
Addresses #84 
Returns content-length: 0 if both the Content and ContentLength properties are null as discussed.
Added an acceptance test for returning Content-Length of 0.
Wasn't sure where to place it and if I the modification I did to the Handle function in the test is alright. Feedback is welcome! :)