### PR TITLE
Stop handling new requests after the server has been stopped

### DIFF
--- a/API/Infrastructure/IServer.cs
+++ b/API/Infrastructure/IServer.cs
@@ -21,6 +21,12 @@ namespace GenHTTP.Api.Infrastructure
         string Version { get; }
 
         /// <summary>
+        /// Specifies, whether the server still serves requests or
+        /// whether it is currently shut down.
+        /// </summary>
+        bool Running { get; }
+
+        /// <summary>
         /// If enabled, components may provide additional information
         /// allowing developers to further debug web applications.
         /// </summary>

--- a/Engine/Infrastructure/ThreadedServer.cs
+++ b/Engine/Infrastructure/ThreadedServer.cs
@@ -19,6 +19,8 @@ namespace GenHTTP.Engine.Infrastructure
 
         public string Version { get; }
 
+        public bool Running => !disposed;
+
         public bool Development => Configuration.DevelopmentMode;
 
         public IHandler Handler { get; private set; }

--- a/Engine/Protocol/ClientHandler.cs
+++ b/Engine/Protocol/ClientHandler.cs
@@ -108,7 +108,7 @@ namespace GenHTTP.Engine
 
                 RequestBuilder? request;
 
-                while ((request = await parser.TryParseAsync(buffer).ConfigureAwait(false)) is not null)
+                while (Server.Running && (request = await parser.TryParseAsync(buffer).ConfigureAwait(false)) is not null)
                 {
                     if (!await HandleRequest(request))
                     {


### PR DESCRIPTION
Simple approach to prevent the server from handling new requests - at least after the current one has been processed.