### PR TITLE
Improve the public Layout builder API

### DIFF
--- a/Modules/Layouting/Provider/LayoutBuilder.cs
+++ b/Modules/Layouting/Provider/LayoutBuilder.cs
@@ -42,7 +42,7 @@ public sealed class LayoutBuilder : IHandlerBuilder<LayoutBuilder>
     /// </summary>
     /// <param name="name">The name of the path segment to be handled</param>
     /// <param name="handler">The handler which will handle the segment</param>
-    public LayoutBuilder Add(string name, IHandler handler) => Add(new HandlerWrapper(handler));
+    public LayoutBuilder Add(string name, IHandler handler) => Add(name, new HandlerWrapper(handler));
 
     /// <summary>
     /// Adds a handler that will be invoked for all URLs below
@@ -54,10 +54,14 @@ public sealed class LayoutBuilder : IHandlerBuilder<LayoutBuilder>
     {
         if (name.Contains('/'))
         {
-            throw new ArgumentException("Path seperators are not allowed in the name of the segment.", nameof(name));
+            return this.Add(name.Split('/', StringSplitOptions.RemoveEmptyEntries), handler);
         }
 
-        RoutedHandlers.Add(name, handler);
+        if (!RoutedHandlers.TryAdd(name, handler))
+        {
+            throw new InvalidOperationException($"A segment with the name '{name}' has already been added to the layout");
+        }
+
         return this;
     }
 

--- a/Testing/Acceptance/Modules/Layouting/LayoutTests.cs
+++ b/Testing/Acceptance/Modules/Layouting/LayoutTests.cs
@@ -80,10 +80,18 @@ public sealed class LayoutTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public void TestIllegalPathCharacters()
+    [MultiEngineTest]
+    public async Task TestMultiSegmentInName(TestEngine engine)
     {
-        Layout.Create().Add("some/path", Content.From(Resource.FromString("Hello World")));
+        var layout = Layout.Create().Add("/api/v1/", Content.From(Resource.FromString("Hello World")));
+
+        await using var runner = await TestHost.RunAsync(layout, engine: engine);
+
+        using var response = await runner.GetResponseAsync("/api/v1/");
+
+        await response.AssertStatusAsync(HttpStatusCode.OK);
+
+        Assert.AreEqual("Hello World", await response.GetContentAsync());
     }
 
     [TestMethod]

--- a/Testing/Acceptance/Modules/Layouting/LayoutTests.cs
+++ b/Testing/Acceptance/Modules/Layouting/LayoutTests.cs
@@ -95,6 +95,17 @@ public sealed class LayoutTests
     }
 
     [TestMethod]
+    public void TestSameSegmentTwice()
+    {
+        var content = Content.From(Resource.FromString("Hello World!"));
+
+        Assert.ThrowsException<InvalidOperationException>(() =>
+        {
+            Layout.Create().Add("one", content).Add("one", content);
+        });
+    }
+
+    [TestMethod]
     [MultiEngineTest]
     public async Task TestLazyBuilding(TestEngine engine)
     {


### PR DESCRIPTION
* Throw a more meaningful exception if the same segment is added twice to a layout
* Do no longer prevent slashes in segment names but threat them as multiple segments