### PR TITLE
Simplify endpoint handling when listening to any IP

### DIFF
--- a/API/Infrastructure/IEndPoint.cs
+++ b/API/Infrastructure/IEndPoint.cs
@@ -8,8 +8,10 @@ namespace GenHTTP.Api.Infrastructure;
 public interface IEndPoint : IDisposable
 {
 
-    // todo
-    IReadOnlyList<IPAddress>? Addresses { get; }
+    /// <summary>
+    /// The IP address the endpoint is bound to.
+    /// </summary>
+    IPAddress? Address { get; }
 
     /// <summary>
     /// The port the endpoint is listening on.

--- a/API/Infrastructure/IEndPoint.cs
+++ b/API/Infrastructure/IEndPoint.cs
@@ -8,14 +8,8 @@ namespace GenHTTP.Api.Infrastructure;
 public interface IEndPoint : IDisposable
 {
 
-    /// <summary>
-    /// The IP address the endpoint is bound to.
-    /// </summary>
-    /// <remarks>
-    /// Can be a specific IPv4/IPv6 address or a more generic one
-    /// such as <see cref="System.Net.IPAddress.Any" />.
-    /// </remarks>
-    IPAddress IPAddress { get; }
+    // todo
+    IReadOnlyList<IPAddress>? Addresses { get; }
 
     /// <summary>
     /// The port the endpoint is listening on.
@@ -26,4 +20,5 @@ public interface IEndPoint : IDisposable
     /// Specifies, whether this is is an endpoint secured via SSL/TLS.
     /// </summary>
     bool Secure { get; }
+
 }

--- a/API/Infrastructure/IServerBuilder.cs
+++ b/API/Infrastructure/IServerBuilder.cs
@@ -33,33 +33,33 @@ public interface IServerBuilder<out T> : IBuilder<IServer>
     /// Registers an endpoint for the given address and port the server will
     /// bind to on startup to listen for incomming HTTP requests.
     /// </summary>
-    /// <param name="address">The address to bind to</param>
+    /// <param name="address">The address to bind to (or null, if the server should listen to any IP)</param>
     /// <param name="port">The port to listen on</param>
-    T Bind(IPAddress address, ushort port);
+    T Bind(IPAddress? address, ushort port);
 
     /// <summary>
     /// Registers a secure endpoint the server will bind to on
     /// startup to listen for incoming HTTPS requests.
     /// </summary>
-    /// <param name="address">The address to bind to</param>
+    /// <param name="address">The address to bind to (or null, if the server should listen to any IP)</param>
     /// <param name="port">The port to listen on</param>
     /// <param name="certificate">The certificate used to negoiate a connection with</param>
     /// <param name="protocols">The SSL/TLS protocl versions which should be supported by the endpoint</param>
     /// <param name="certificateValidator">The validator to check the validity of client certificates with</param>
     /// <param name="enableQuic">If enabled, the server will host a HTTP/3 endpoint via QUIC</param>
-    T Bind(IPAddress address, ushort port, X509Certificate2 certificate, SslProtocols protocols = SslProtocols.Tls12 | SslProtocols.Tls13, ICertificateValidator? certificateValidator = null, bool enableQuic = false);
+    T Bind(IPAddress? address, ushort port, X509Certificate2 certificate, SslProtocols protocols = SslProtocols.Tls12 | SslProtocols.Tls13, ICertificateValidator? certificateValidator = null, bool enableQuic = false);
 
     /// <summary>
     /// Registers a secure endpoint the server will bind to on
     /// startup to listen for incoming HTTPS requests.
     /// </summary>
-    /// <param name="address">The address to bind to</param>
+    /// <param name="address">The address to bind to (or null, if the server should listen to any IP)</param>
     /// <param name="port">The port to listen on</param>
     /// <param name="certificateProvider">The provider to select the certificate used to negoiate a connection with</param>
     /// <param name="protocols">The SSL/TLS protocl versions which should be supported by the endpoint</param>
     /// <param name="certificateValidator">The validator to check the validity of client certificates with</param>
     /// <param name="enableQuic">If enabled, the server will host a HTTP/3 endpoint via QUIC</param>
-    T Bind(IPAddress address, ushort port, ICertificateProvider certificateProvider, SslProtocols protocols = SslProtocols.Tls12 | SslProtocols.Tls13, ICertificateValidator? certificateValidator = null, bool enableQuic = false);
+    T Bind(IPAddress? address, ushort port, ICertificateProvider certificateProvider, SslProtocols protocols = SslProtocols.Tls12 | SslProtocols.Tls13, ICertificateValidator? certificateValidator = null, bool enableQuic = false);
 
     #endregion
 

--- a/Engine/Internal/Infrastructure/Endpoints/EndPoint.cs
+++ b/Engine/Internal/Infrastructure/Endpoints/EndPoint.cs
@@ -21,7 +21,7 @@ internal abstract class EndPoint : IEndPoint
 
     private Socket? Socket { get; set; }
 
-    public IReadOnlyList<IPAddress>? Addresses { get; }
+    public IPAddress? Address { get; }
 
     public ushort Port { get; }
 
@@ -31,13 +31,13 @@ internal abstract class EndPoint : IEndPoint
 
     #region Initialization
 
-    protected EndPoint(IServer server, IReadOnlyList<IPAddress>? addresses, ushort port, NetworkConfiguration configuration)
+    protected EndPoint(IServer server, IPAddress? address, ushort port, NetworkConfiguration configuration)
     {
         Server = server;
 
         Configuration = configuration;
 
-        Addresses = addresses;
+        Address = address;
         Port = port;
     }
 
@@ -47,7 +47,7 @@ internal abstract class EndPoint : IEndPoint
 
     public void Start()
     {
-        var bindings = Addresses ?? [ IPAddress.IPv6Any ];
+        var address = Address ?? IPAddress.IPv6Any;
 
         try
         {
@@ -55,16 +55,13 @@ internal abstract class EndPoint : IEndPoint
 
             Socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, false);
 
-            foreach (var address in bindings)
-            {
-                Socket.Bind(new IPEndPoint(address, Port));
-            }
+            Socket.Bind(new IPEndPoint(address, Port));
 
             Socket.Listen(Configuration.Backlog);
         }
         catch (Exception e)
         {
-            throw new BindingException($"Failed to bind to on [ {string.Join(", ", bindings)} ] port {Port}.", e);
+            throw new BindingException($"Failed to bind to on {address} port {Port}.", e);
         }
 
         Task = Task.Run(Listen);

--- a/Engine/Internal/Infrastructure/Endpoints/EndPoint.cs
+++ b/Engine/Internal/Infrastructure/Endpoints/EndPoint.cs
@@ -61,7 +61,7 @@ internal abstract class EndPoint : IEndPoint
         }
         catch (Exception e)
         {
-            throw new BindingException($"Failed to bind to on {address} port {Port}.", e);
+            throw new BindingException($"Failed to bind to {address} on port {Port}.", e);
         }
 
         Task = Task.Run(Listen);

--- a/Engine/Internal/Infrastructure/Endpoints/EndPoint.cs
+++ b/Engine/Internal/Infrastructure/Endpoints/EndPoint.cs
@@ -58,6 +58,8 @@ internal abstract class EndPoint : IEndPoint
         {
             Socket = new Socket(Endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 
+            Socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, false);
+
             Socket.Bind(Endpoint);
             Socket.Listen(Configuration.Backlog);
         }

--- a/Engine/Internal/Infrastructure/Endpoints/EndpointCollection.cs
+++ b/Engine/Internal/Infrastructure/Endpoints/EndpointCollection.cs
@@ -30,10 +30,10 @@ internal sealed class EndPointCollection : List<IEndPoint>, IDisposable, IEndPoi
     {
         if (configuration.Security is null)
         {
-            return new InsecureEndPoint(Server, configuration.Addresses, configuration.Port, NetworkConfiguration);
+            return new InsecureEndPoint(Server, configuration.Address, configuration.Port, NetworkConfiguration);
         }
 
-        return new SecureEndPoint(Server, configuration.Addresses, configuration.Port, configuration.Security, NetworkConfiguration);
+        return new SecureEndPoint(Server, configuration.Address, configuration.Port, configuration.Security, NetworkConfiguration);
     }
 
     internal void Start()

--- a/Engine/Internal/Infrastructure/Endpoints/EndpointCollection.cs
+++ b/Engine/Internal/Infrastructure/Endpoints/EndpointCollection.cs
@@ -1,6 +1,4 @@
-﻿using System.Net;
-
-using GenHTTP.Api.Infrastructure;
+﻿using GenHTTP.Api.Infrastructure;
 
 using GenHTTP.Engine.Shared.Infrastructure;
 

--- a/Engine/Internal/Infrastructure/Endpoints/EndpointCollection.cs
+++ b/Engine/Internal/Infrastructure/Endpoints/EndpointCollection.cs
@@ -28,13 +28,12 @@ internal sealed class EndPointCollection : List<IEndPoint>, IDisposable, IEndPoi
 
     private EndPoint Build(EndPointConfiguration configuration)
     {
-        var endpoint = new IPEndPoint(configuration.Address, configuration.Port);
-
         if (configuration.Security is null)
         {
-            return new InsecureEndPoint(Server, endpoint, NetworkConfiguration);
+            return new InsecureEndPoint(Server, configuration.Addresses, configuration.Port, NetworkConfiguration);
         }
-        return new SecureEndPoint(Server, endpoint, configuration.Security, NetworkConfiguration);
+
+        return new SecureEndPoint(Server, configuration.Addresses, configuration.Port, configuration.Security, NetworkConfiguration);
     }
 
     internal void Start()

--- a/Engine/Internal/Infrastructure/Endpoints/InsecureEndPoint.cs
+++ b/Engine/Internal/Infrastructure/Endpoints/InsecureEndPoint.cs
@@ -15,8 +15,8 @@ internal sealed class InsecureEndPoint : EndPoint
 
     #region Initialization
 
-    internal InsecureEndPoint(IServer server, IReadOnlyList<IPAddress>? addresses, ushort port, NetworkConfiguration configuration)
-        : base(server, addresses, port, configuration)
+    internal InsecureEndPoint(IServer server, IPAddress? address, ushort port, NetworkConfiguration configuration)
+        : base(server, address, port, configuration)
     {
 
     }

--- a/Engine/Internal/Infrastructure/Endpoints/InsecureEndPoint.cs
+++ b/Engine/Internal/Infrastructure/Endpoints/InsecureEndPoint.cs
@@ -15,8 +15,8 @@ internal sealed class InsecureEndPoint : EndPoint
 
     #region Initialization
 
-    internal InsecureEndPoint(IServer server, IPEndPoint endPoint, NetworkConfiguration configuration)
-        : base(server, endPoint, configuration)
+    internal InsecureEndPoint(IServer server, IReadOnlyList<IPAddress>? addresses, ushort port, NetworkConfiguration configuration)
+        : base(server, addresses, port, configuration)
     {
 
     }

--- a/Engine/Internal/Infrastructure/Endpoints/SecureEndPoint.cs
+++ b/Engine/Internal/Infrastructure/Endpoints/SecureEndPoint.cs
@@ -28,8 +28,8 @@ internal sealed class SecureEndPoint : EndPoint
 
     #region Initialization
 
-    internal SecureEndPoint(IServer server, IPEndPoint endPoint, SecurityConfiguration options, NetworkConfiguration configuration)
-        : base(server, endPoint, configuration)
+    internal SecureEndPoint(IServer server, IReadOnlyList<IPAddress>? addresses, ushort port, SecurityConfiguration options, NetworkConfiguration configuration)
+        : base(server, addresses, port, configuration)
     {
         Options = options;
 

--- a/Engine/Internal/Infrastructure/Endpoints/SecureEndPoint.cs
+++ b/Engine/Internal/Infrastructure/Endpoints/SecureEndPoint.cs
@@ -28,8 +28,8 @@ internal sealed class SecureEndPoint : EndPoint
 
     #region Initialization
 
-    internal SecureEndPoint(IServer server, IReadOnlyList<IPAddress>? addresses, ushort port, SecurityConfiguration options, NetworkConfiguration configuration)
-        : base(server, addresses, port, configuration)
+    internal SecureEndPoint(IServer server, IPAddress? address, ushort port, SecurityConfiguration options, NetworkConfiguration configuration)
+        : base(server, address, port, configuration)
     {
         Options = options;
 

--- a/Engine/Kestrel/Hosting/KestrelEndpoint.cs
+++ b/Engine/Kestrel/Hosting/KestrelEndpoint.cs
@@ -8,7 +8,7 @@ public sealed class KestrelEndpoint : IEndPoint
 
     #region Get-/Setters
 
-    public IReadOnlyList<IPAddress>? Addresses { get; }
+    public IPAddress? Address { get; }
 
     public ushort Port { get; }
 
@@ -18,9 +18,9 @@ public sealed class KestrelEndpoint : IEndPoint
 
     #region Initialization
 
-    public KestrelEndpoint(IReadOnlyList<IPAddress>? addresses, ushort port, bool secure)
+    public KestrelEndpoint(IPAddress? address, ushort port, bool secure)
     {
-        Addresses = addresses;
+        Address = address;
         Port = port;
         Secure = secure;
     }

--- a/Engine/Kestrel/Hosting/KestrelEndpoint.cs
+++ b/Engine/Kestrel/Hosting/KestrelEndpoint.cs
@@ -8,7 +8,7 @@ public sealed class KestrelEndpoint : IEndPoint
 
     #region Get-/Setters
 
-    public IPAddress IPAddress { get; }
+    public IReadOnlyList<IPAddress>? Addresses { get; }
 
     public ushort Port { get; }
 
@@ -18,9 +18,9 @@ public sealed class KestrelEndpoint : IEndPoint
 
     #region Initialization
 
-    public KestrelEndpoint(IPAddress ipAddress, ushort port, bool secure)
+    public KestrelEndpoint(IReadOnlyList<IPAddress>? addresses, ushort port, bool secure)
     {
-        IPAddress = ipAddress;
+        Addresses = addresses;
         Port = port;
         Secure = secure;
     }

--- a/Engine/Kestrel/Hosting/KestrelServer.cs
+++ b/Engine/Kestrel/Hosting/KestrelServer.cs
@@ -2,7 +2,6 @@
 using System.Security.Cryptography.X509Certificates;
 
 using GenHTTP.Adapters.AspNetCore;
-
 using GenHTTP.Api.Content;
 using GenHTTP.Api.Infrastructure;
 
@@ -55,7 +54,7 @@ internal sealed class KestrelServer : IServer
 
         var endpoints = new KestrelEndpoints();
 
-        endpoints.AddRange(configuration.EndPoints.Select(e => new KestrelEndpoint(e.Addresses, e.Port, e.Security is not null)));
+        endpoints.AddRange(configuration.EndPoints.Select(e => new KestrelEndpoint(e.Address, e.Port, e.Security is not null)));
 
         EndPoints = endpoints;
 
@@ -104,25 +103,22 @@ internal sealed class KestrelServer : IServer
 
             foreach (var endpoint in Configuration.EndPoints)
             {
-                if (endpoint.Addresses != null)
+                if (endpoint.Address != null)
                 {
-                    foreach (var address in endpoint.Addresses)
+                    if (endpoint.Security != null)
                     {
-                        if (endpoint.Security != null)
-                        {
-                            options.Listen(address, endpoint.Port, listenOptions => Secure(listenOptions, endpoint, endpoint.Security));
-                        }
-                        else
-                        {
-                            options.Listen(address, endpoint.Port);
-                        }
+                        options.Listen(endpoint.Address, endpoint.Port, listenOptions => Secure(listenOptions, endpoint, endpoint.Security));
+                    }
+                    else
+                    {
+                        options.Listen(endpoint.Address, endpoint.Port);
                     }
                 }
                 else
                 {
                     if (endpoint.Security != null)
                     {
-                        options.ListenAnyIP(endpoint.Port,listenOptions => Secure(listenOptions, endpoint, endpoint.Security));
+                        options.ListenAnyIP(endpoint.Port, listenOptions => Secure(listenOptions, endpoint, endpoint.Security));
                     }
                     else
                     {

--- a/Engine/Shared/Hosting/ServerHost.cs
+++ b/Engine/Shared/Hosting/ServerHost.cs
@@ -35,19 +35,19 @@ public sealed class ServerHost : IServerHost
         return this;
     }
 
-    public IServerHost Bind(IPAddress address, ushort port)
+    public IServerHost Bind(IPAddress? address, ushort port)
     {
         _Builder.Bind(address, port);
         return this;
     }
 
-    public IServerHost Bind(IPAddress address, ushort port, X509Certificate2 certificate, SslProtocols protocols = SslProtocols.Tls12 | SslProtocols.Tls13, ICertificateValidator? certificateValidator = null, bool enableQuic = false)
+    public IServerHost Bind(IPAddress? address, ushort port, X509Certificate2 certificate, SslProtocols protocols = SslProtocols.Tls12 | SslProtocols.Tls13, ICertificateValidator? certificateValidator = null, bool enableQuic = false)
     {
         _Builder.Bind(address, port, certificate, protocols, certificateValidator, enableQuic);
         return this;
     }
 
-    public IServerHost Bind(IPAddress address, ushort port, ICertificateProvider certificateProvider, SslProtocols protocols = SslProtocols.Tls12 | SslProtocols.Tls13, ICertificateValidator? certificateValidator = null, bool enableQuic = false)
+    public IServerHost Bind(IPAddress? address, ushort port, ICertificateProvider certificateProvider, SslProtocols protocols = SslProtocols.Tls12 | SslProtocols.Tls13, ICertificateValidator? certificateValidator = null, bool enableQuic = false)
     {
         _Builder.Bind(address, port, certificateProvider, protocols, certificateValidator, enableQuic);
         return this;

--- a/Engine/Shared/Infrastructure/Configuration.cs
+++ b/Engine/Shared/Infrastructure/Configuration.cs
@@ -11,6 +11,6 @@ public record ServerConfiguration(bool DevelopmentMode, IEnumerable<EndPointConf
 public record NetworkConfiguration(TimeSpan RequestReadTimeout, uint RequestMemoryLimit,
     uint TransferBufferSize, ushort Backlog);
 
-public record EndPointConfiguration(IPAddress Address, ushort Port, SecurityConfiguration? Security, bool EnableQuic);
+public record EndPointConfiguration(IReadOnlyList<IPAddress>? Addresses, ushort Port, SecurityConfiguration? Security, bool EnableQuic);
 
 public record SecurityConfiguration(ICertificateProvider CertificateProvider, SslProtocols Protocols, ICertificateValidator? CertificateValidator);

--- a/Engine/Shared/Infrastructure/Configuration.cs
+++ b/Engine/Shared/Infrastructure/Configuration.cs
@@ -11,6 +11,6 @@ public record ServerConfiguration(bool DevelopmentMode, IEnumerable<EndPointConf
 public record NetworkConfiguration(TimeSpan RequestReadTimeout, uint RequestMemoryLimit,
     uint TransferBufferSize, ushort Backlog);
 
-public record EndPointConfiguration(IReadOnlyList<IPAddress>? Addresses, ushort Port, SecurityConfiguration? Security, bool EnableQuic);
+public record EndPointConfiguration(IPAddress? Address, ushort Port, SecurityConfiguration? Security, bool EnableQuic);
 
 public record SecurityConfiguration(ICertificateProvider CertificateProvider, SslProtocols Protocols, ICertificateValidator? CertificateValidator);

--- a/Engine/Shared/Infrastructure/ServerBuilder.cs
+++ b/Engine/Shared/Infrastructure/ServerBuilder.cs
@@ -87,9 +87,11 @@ public abstract class ServerBuilder : IServerBuilder
         return this;
     }
 
+    // todo: overloads for multiple adresses and no adresses
+
     public IServerBuilder Bind(IPAddress address, ushort port)
     {
-        _EndPoints.Add(new EndPointConfiguration(address, port, null, false));
+        _EndPoints.Add(new EndPointConfiguration([address], port, null, false));
         return this;
     }
 
@@ -97,7 +99,7 @@ public abstract class ServerBuilder : IServerBuilder
 
     public IServerBuilder Bind(IPAddress address, ushort port, ICertificateProvider certificateProvider, SslProtocols protocols = SslProtocols.Tls12 | SslProtocols.Tls13, ICertificateValidator? certificateValidator = null, bool enableQuic = false)
     {
-        _EndPoints.Add(new EndPointConfiguration(address, port, new SecurityConfiguration(certificateProvider, protocols, certificateValidator), enableQuic));
+        _EndPoints.Add(new EndPointConfiguration([address], port, new SecurityConfiguration(certificateProvider, protocols, certificateValidator), enableQuic));
         return this;
     }
 
@@ -146,17 +148,7 @@ public abstract class ServerBuilder : IServerBuilder
 
         if (endpoints.Count == 0)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                endpoints.Add(new EndPointConfiguration(IPAddress.Any, _Port, null, false));
-                endpoints.Add(new EndPointConfiguration(IPAddress.IPv6Any, _Port, null, false));
-            }
-            else
-            {
-                // we cannot bind to both IPv6 and IPv4 on linux
-                // listening to IPv6 will also listen to IPv4 due to dual-stack
-                endpoints.Add(new EndPointConfiguration(IPAddress.IPv6Any, _Port, null, false));
-            }
+            endpoints.Add(new EndPointConfiguration(null, _Port, null, false));
         }
 
         var config = new ServerConfiguration(_Development, endpoints, network);

--- a/Engine/Shared/Infrastructure/ServerBuilder.cs
+++ b/Engine/Shared/Infrastructure/ServerBuilder.cs
@@ -87,19 +87,17 @@ public abstract class ServerBuilder : IServerBuilder
         return this;
     }
 
-    // todo: overloads for multiple adresses and no adresses
-
-    public IServerBuilder Bind(IPAddress address, ushort port)
+    public IServerBuilder Bind(IPAddress? address, ushort port)
     {
-        _EndPoints.Add(new EndPointConfiguration([address], port, null, false));
+        _EndPoints.Add(new EndPointConfiguration(address, port, null, false));
         return this;
     }
 
-    public IServerBuilder Bind(IPAddress address, ushort port, X509Certificate2 certificate, SslProtocols protocols = SslProtocols.Tls12 | SslProtocols.Tls13, ICertificateValidator? certificateValidator = null, bool enableQuic = false) => Bind(address, port, new SimpleCertificateProvider(certificate), protocols, certificateValidator, enableQuic);
+    public IServerBuilder Bind(IPAddress? address, ushort port, X509Certificate2 certificate, SslProtocols protocols = SslProtocols.Tls12 | SslProtocols.Tls13, ICertificateValidator? certificateValidator = null, bool enableQuic = false) => Bind(address, port, new SimpleCertificateProvider(certificate), protocols, certificateValidator, enableQuic);
 
-    public IServerBuilder Bind(IPAddress address, ushort port, ICertificateProvider certificateProvider, SslProtocols protocols = SslProtocols.Tls12 | SslProtocols.Tls13, ICertificateValidator? certificateValidator = null, bool enableQuic = false)
+    public IServerBuilder Bind(IPAddress? address, ushort port, ICertificateProvider certificateProvider, SslProtocols protocols = SslProtocols.Tls12 | SslProtocols.Tls13, ICertificateValidator? certificateValidator = null, bool enableQuic = false)
     {
-        _EndPoints.Add(new EndPointConfiguration([address], port, new SecurityConfiguration(certificateProvider, protocols, certificateValidator), enableQuic));
+        _EndPoints.Add(new EndPointConfiguration(address, port, new SecurityConfiguration(certificateProvider, protocols, certificateValidator), enableQuic));
         return this;
     }
 

--- a/Engine/Shared/Infrastructure/ServerBuilder.cs
+++ b/Engine/Shared/Infrastructure/ServerBuilder.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net;
-using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 

--- a/Engine/Shared/Infrastructure/ServerBuilder.cs
+++ b/Engine/Shared/Infrastructure/ServerBuilder.cs
@@ -153,7 +153,9 @@ public abstract class ServerBuilder : IServerBuilder
             }
             else
             {
-                endpoints.Add(new EndPointConfiguration(IPAddress.Any, _Port, null, false));
+                // we cannot bind to both IPv6 and IPv4 on linux
+                // listening to IPv6 will also listen to IPv4 due to dual-stack
+                endpoints.Add(new EndPointConfiguration(IPAddress.IPv6Any, _Port, null, false));
             }
         }
 

--- a/Modules/Inspection/Concern/InspectionConcern.cs
+++ b/Modules/Inspection/Concern/InspectionConcern.cs
@@ -53,7 +53,7 @@ public sealed class InspectionConcern : IConcern
                     Endpoints = server.EndPoints.Select(e => new
                     {
                         Port = e.Port,
-                        IPAddress = e.Addresses?.Select(a => a.ToString()),
+                        IPAddress = e.Address?.ToString(),
                         Secure = e.Secure,
                         RequestSource = e == request.EndPoint
                     })

--- a/Modules/Inspection/Concern/InspectionConcern.cs
+++ b/Modules/Inspection/Concern/InspectionConcern.cs
@@ -53,7 +53,7 @@ public sealed class InspectionConcern : IConcern
                     Endpoints = server.EndPoints.Select(e => new
                     {
                         Port = e.Port,
-                        IPAddress = e.IPAddress.ToString(),
+                        IPAddress = e.Addresses?.Select(a => a.ToString()),
                         Secure = e.Secure,
                         RequestSource = e == request.EndPoint
                     })


### PR DESCRIPTION
Allow to `ListenAnyIP()` in Kestrel and therefore enable IPv6 support there.