### PR TITLE
Do not send a `Keep-Alive` header for HTTP/1.1

### DIFF
--- a/Engine/Internal/Protocol/ClientHandler.cs
+++ b/Engine/Internal/Protocol/ClientHandler.cs
@@ -166,7 +166,7 @@ internal sealed class ClientHandler
             return ConnectionStatus.Upgraded;
         }
 
-        var active = await ResponseHandler.Handle(request, response, keepAlive, dataRemaining);
+        var active = await ResponseHandler.Handle(request, response, request.ProtocolType, keepAlive, dataRemaining);
 
         return (active && keepAlive) ? ConnectionStatus.KeepAlive : ConnectionStatus.Close;
     }
@@ -181,7 +181,7 @@ internal sealed class ClientHandler
                                                 .Content(new StringContent(message))
                                                 .Build();
 
-            await ResponseHandler.Handle(null, response, false, false);
+            await ResponseHandler.Handle(null, response, HttpProtocol.Http10, false, false);
         }
         catch
         {

--- a/Testing/Acceptance/Engine/BasicTests.cs
+++ b/Testing/Acceptance/Engine/BasicTests.cs
@@ -65,13 +65,13 @@ public sealed class BasicTests
     }
 
     [TestMethod]
-    public async Task TestKeepalive()
+    public async Task TestNoKeepAliveHeaderOn11()
     {
         await using var runner = await TestHost.RunAsync(Layout.Create());
 
         using var response = await runner.GetResponseAsync();
 
-        Assert.Contains("Keep-Alive", response.Headers.Connection);
+        Assert.DoesNotContain("Keep-Alive", response.Headers.Connection);
     }
 
 }

--- a/Testing/Acceptance/Engine/KeepAliveTests.cs
+++ b/Testing/Acceptance/Engine/KeepAliveTests.cs
@@ -1,0 +1,52 @@
+﻿using System.Net;
+using System.Net.Sockets;
+
+using GenHTTP.Api.Content;
+using GenHTTP.Api.Protocol;
+
+using GenHTTP.Modules.Functional;
+
+namespace GenHTTP.Testing.Acceptance.Engine;
+
+[TestClass]
+public class KeepAliveTests
+{
+
+    /// <summary>
+    /// This is a white box test that verifies that two subsequent requests
+    /// to the server from the same client reuse the same connection,
+    /// thus verifying that keep-alive connections are supported.
+    /// </summary>
+    [TestMethod]
+    public async Task TestKeepAlive()
+    {
+        Socket? connection = null;
+
+        var tester = Inline.Create()
+                           .Get((IRequest r) =>
+                           {
+                               var socket = r.Upgrade().Socket;
+
+                               if (connection == null)
+                               {
+                                   connection = socket;
+                               }
+                               else
+                               {
+                                   if (connection != socket)
+                                   {
+                                       throw new ProviderException(ResponseStatus.BadRequest, "Client connection did change, so this is not a keep-alive request");
+                                   }
+                               }
+                           });
+
+        await using var runner = await TestHost.RunAsync(tester, engine: TestEngine.Internal);
+
+        using var r1 = await runner.GetResponseAsync();
+        await r1.AssertStatusAsync(HttpStatusCode.NoContent);
+
+        using var r2 = await runner.GetResponseAsync();
+        await r2.AssertStatusAsync(HttpStatusCode.NoContent);
+    }
+
+}


### PR DESCRIPTION
In HTTP/1.1 and onward, persistent connections are used by default, so we do not need to send a `Keep-Alive` header to indicate this.