### PR TITLE
Fix the request scope being immediately disposed without awaiting the handler chain

### DIFF
--- a/Modules/DependencyInjection/Infrastructure/InjectionConcern.cs
+++ b/Modules/DependencyInjection/Infrastructure/InjectionConcern.cs
@@ -29,13 +29,13 @@ internal class InjectionConcern : IConcern
 
     public ValueTask PrepareAsync() => Content.PrepareAsync();
 
-    public ValueTask<IResponse?> HandleAsync(IRequest request)
+    public async ValueTask<IResponse?> HandleAsync(IRequest request)
     {
         using var scope = Services.CreateScope();
 
         request.Configure(Services, scope);
 
-        return Content.HandleAsync(request);
+        return await Content.HandleAsync(request);
     }
 
     #endregion


### PR DESCRIPTION
Context.HandleAsync must be awaited to ensure code is executed fully with a returned response before scope is disposed.