### PR TITLE
Add LiquidPages project reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ in C#. In 2024 the focus has shifted towards API development, dropping support f
 - Related to
   GenHTTP: [Templates](https://github.com/Kaliumhexacyanoferrat/GenHTTP.Templates) | [Website](https://github.com/Kaliumhexacyanoferrat/GenHTTP.Website)
 - Reference
-  projects: [GenHTTP Gateway](https://github.com/Kaliumhexacyanoferrat/GenHTTP.Gateway) | [MockH](https://github.com/Kaliumhexacyanoferrat/MockH)
+  projects: [GenHTTP Gateway](https://github.com/Kaliumhexacyanoferrat/GenHTTP.Gateway) | [MockH](https://github.com/Kaliumhexacyanoferrat/MockH) | [LiquidPages](https://github.com/kinetq/liquid-pages)
 - Similar
   projects: [Wired.IO](https://github.com/MDA2AV/Wired.IO) | [Unhinged](https://github.com/MDA2AV/unhinged) | [SimpleW](https://github.com/stratdev3/SimpleW) | [Sisk](https://www.sisk-framework.org/) |  [NetCoreServer](https://github.com/chronoxor/NetCoreServer) | [Watson Webserver](https://github.com/jchristn/WatsonWebserver) | [EmbedIO](https://github.com/unosquare/embedio)
 


### PR DESCRIPTION
Hello!

I set up a library where routes and liquid templates (along with their assets) could be defined in any C# project within a solution. I was also looking for more of an MVVM approach as apposed to MVC and I wanted to be able to use any web server.

I've recently created a Handler to integrate LiquidPages with GenHTTP. You can view it here: https://github.com/kinetq/liquid-pages/tree/master/src/Kinetq.LiquidPages.GenHTTP