### PR TITLE
Fix results returned by tasks not being respected

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
 
         <AssemblyVersion>11.0.0.0</AssemblyVersion>
         <FileVersion>11.0.0.0</FileVersion>
-        <Version>11.0.0-preview.13</Version>
+        <Version>11.0.0-preview.14</Version>
 
         <Authors>Andreas Nägeli</Authors>
 

--- a/Modules/Reflection/Generation/CompilationUtil.cs
+++ b/Modules/Reflection/Generation/CompilationUtil.cs
@@ -74,7 +74,12 @@ public static class CompilationUtil
     internal static bool HasWrappedResult(Operation operation)
     {
         var returnType = operation.Method.ReturnType;
-        
+
+        if (returnType.IsAsyncGeneric())
+        {
+            returnType = returnType.GenericTypeArguments[0];
+        }
+
         return typeof(IResultWrapper).IsAssignableFrom(returnType);
     }
 

--- a/Packages/GenHTTP.Core.nuspec
+++ b/Packages/GenHTTP.Core.nuspec
@@ -3,7 +3,7 @@
     <metadata>
 
         <id>GenHTTP.Core</id>
-        <version>11.0.0-preview.13</version>
+        <version>11.0.0-preview.14</version>
 
         <description>Basic dependencies for projects using the GenHTTP framework, including the engine itself</description>
 
@@ -22,14 +22,14 @@
 
             <group>
 
-                <dependency id="GenHTTP.Api" version="11.0.0-preview.13"/>
+                <dependency id="GenHTTP.Api" version="11.0.0-preview.14"/>
 
-                <dependency id="GenHTTP.Engine.Internal" version="11.0.0-preview.13"/>
+                <dependency id="GenHTTP.Engine.Internal" version="11.0.0-preview.14"/>
 
                 <!--<dependency id="GenHTTP.Modules.Practices" version="11.0.0"/>-->
 
-                <dependency id="GenHTTP.Modules.IO" version="11.0.0-preview.13"/>
-                <dependency id="GenHTTP.Modules.Layouting" version="11.0.0-preview.13"/>
+                <dependency id="GenHTTP.Modules.IO" version="11.0.0-preview.14"/>
+                <dependency id="GenHTTP.Modules.Layouting" version="11.0.0-preview.14"/>
 
             </group>
 

--- a/Testing/Acceptance/Modules/Reflection/ResultTests.cs
+++ b/Testing/Acceptance/Modules/Reflection/ResultTests.cs
@@ -26,10 +26,8 @@ public sealed class ResultTests
     public async Task TestResponseCanBeModified(TestEngine engine, ExecutionMode mode)
     {
         var result = new Result<MyPayload>(new MyPayload("Hello World!"))
-                     .Status(ResponseStatus.Accepted)
-                     // todo: .Status() //, "Accepted Custom")
+                     .Status(ResponseStatus.Created)
                      .Connection(Connection.Close)
-                     // .Type(new FlexibleContentType(ContentType.TextRichText))
                      .Header("X-Custom", "Value")
                      .Cookie(new Cookie("Cookie", "Value"));
 
@@ -41,7 +39,7 @@ public sealed class ResultTests
 
         using var response = await runner.GetResponseAsync();
 
-        await response.AssertStatusAsync(HttpStatusCode.Accepted);
+        await response.AssertStatusAsync(HttpStatusCode.Created);
 
         Assert.AreEqual("Value", response.GetHeader("X-Custom"));
 

--- a/Testing/Acceptance/Modules/Webservices/WebserviceTests.cs
+++ b/Testing/Acceptance/Modules/Webservices/WebserviceTests.cs
@@ -50,6 +50,10 @@ public sealed class WebserviceTests
         [ResourceMethod(Method.Post, "entity")]
         public TestEntity Entity(TestEntity entity) => entity;
 
+        [ResourceMethod(Method.Get, "entity-result")]
+        public Task<Result<TestEntity>> EntityResultAsync()
+            => Task.FromResult(new Result<TestEntity>(new() { Id = 12}).Status(ResponseStatus.Created));
+
         [ResourceMethod(Method.Put, "stream")]
         public Stream Stream(Stream input) => new MemoryStream(Encoding.UTF8.GetBytes(input.Length.ToString()));
 
@@ -197,6 +201,13 @@ public sealed class WebserviceTests
     {
         const string entity = "{\"id\":42,\"nullable\":123.456}";
         await WithResponse(engine, mode, "entity", HttpMethod.Post, entity, null, "bla/blubb", async r => Assert.AreEqual(entity, await r.GetContentAsync()));
+    }
+
+    [TestMethod]
+    [MultiEngineFrameworkTest]
+    public async Task TestEntityWithResult(TestEngine engine, ExecutionMode mode)
+    {
+        await WithResponse(engine, mode, "entity-result", HttpMethod.Get, null, null, null, async r => await r.AssertStatusAsync(HttpStatusCode.Created));
     }
 
     [TestMethod]


### PR DESCRIPTION
In code generation mode (which is now the default), the following code does not return HTTP status `201`:

```csharp
[ResourceMethod(Method.Get, "entity-result")]
public Task<Result<TestEntity>> EntityResultAsync() 
   => Task.FromResult(new Result<TestEntity>(new() { Id = 12}).Status(ResponseStatus.Created));
```