### PR TITLE
Further optimize memory view generated types

### DIFF
--- a/API/Protocol/IKeyValueList.Extensions.cs
+++ b/API/Protocol/IKeyValueList.Extensions.cs
@@ -17,7 +17,7 @@ public static class IKeyValueListExtensions
 
             if (entry.Key == key)
             {
-                return entry.Value;
+                return new(entry.Value);
             }
         }
 

--- a/API/Protocol/IKeyValueList.Extensions.cs
+++ b/API/Protocol/IKeyValueList.Extensions.cs
@@ -13,7 +13,7 @@ public static class IKeyValueListExtensions
     {
         for (var i = 0; i < list.Count; i++)
         {
-            var entry = list[i];
+            var entry = list.GetMemoryEntry(i);
 
             if (entry.Key == key)
             {
@@ -43,7 +43,7 @@ public static class IKeyValueListExtensions
     {
         for (var i = 0; i < list.Count; i++)
         {
-            if (list[i].Key == key)
+            if (list.GetMemoryEntry(i).Key == key)
                 return true;
         }
 
@@ -58,5 +58,18 @@ public static class IKeyValueListExtensions
     /// <returns>true, if the list contains an entry with that key, otherwise false</returns>
     public static bool ContainsKey(this IKeyValueList list, string key)
         => list.ContainsKey(new ByteString(key));
+
+    /// <summary>
+    /// Fetches an entry of the list by index and converts it into byte strings.
+    /// </summary>
+    /// <param name="list">The list to get the entry from</param>
+    /// <param name="index">The zero based index of the item to be fetched</param>
+    /// <returns>The entry as byte strings</returns>
+    public static KeyValuePair<ByteString, ByteString> GetStringEntry(this IKeyValueList list, int index)
+    {
+        var entry = list.GetMemoryEntry(index);
+
+        return new(new ByteString(entry.Key), new ByteString(entry.Value));
+    }
 
 }

--- a/API/Protocol/IKeyValueList.cs
+++ b/API/Protocol/IKeyValueList.cs
@@ -21,6 +21,6 @@ public interface IKeyValueList
     /// Fetches the entry with the given index.
     /// </summary>
     /// <param name="index">The zero based index of the entry to fetch</param>
-    KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> this[int index] { get; }
+    KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> GetMemoryEntry(int index);
 
 }

--- a/API/Protocol/IKeyValueList.cs
+++ b/API/Protocol/IKeyValueList.cs
@@ -17,6 +17,10 @@ public interface IKeyValueList
     /// </summary>
     int Count { get; }
 
+    /// <summary>
+    /// Fetches the entry with the given index.
+    /// </summary>
+    /// <param name="index">The zero based index of the entry to fetch</param>
     KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> this[int index] { get; }
 
 }

--- a/API/Protocol/IKeyValueList.cs
+++ b/API/Protocol/IKeyValueList.cs
@@ -17,10 +17,6 @@ public interface IKeyValueList
     /// </summary>
     int Count { get; }
 
-    /// <summary>
-    /// Fetches the entry with the given index.
-    /// </summary>
-    /// <param name="index">The zero-based index of the item to fetch</param>
-    KeyValuePair<ByteString, ByteString> this[int index] { get; }
+    KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> this[int index] { get; }
 
 }

--- a/API/Protocol/IRequestHeaders.Cookies.cs
+++ b/API/Protocol/IRequestHeaders.Cookies.cs
@@ -53,7 +53,7 @@ public static class CookieHeaderExtensions
     /// <returns>The cookies found in the given headers</returns>
     public static IKeyValueList GetCookies(this IRequestHeaders headers)
     {
-        var cookies = new List<KeyValuePair<ByteString, ByteString>>();
+        var cookies = new List<KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>>();
 
         for (var i = 0; i < headers.Count; i++)
         {
@@ -72,10 +72,9 @@ public static class CookieHeaderExtensions
 
     #region Parsing
 
-    private static ByteString? FindCookie(ByteString header, ByteString key)
+    private static ByteString? FindCookie(ReadOnlyMemory<byte> header, ByteString key)
     {
-        var memory = header.Bytes;
-        var span = memory.Span;
+        var span = header.Span;
 
         var keySpan = key.Bytes.Span;
 
@@ -85,22 +84,20 @@ public static class CookieHeaderExtensions
         {
             if (span[segments.Name].SequenceEqual(keySpan))
             {
-                return new ByteString(memory[segments.Value]);
+                return new ByteString(header[segments.Value]);
             }
         }
 
         return null;
     }
 
-    private static void ParseCookies(ByteString header, List<KeyValuePair<ByteString, ByteString>> target)
+    private static void ParseCookies(ReadOnlyMemory<byte> header, List<KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>> target)
     {
-        var memory = header.Bytes;
-
-        var segments = new CookieSegments(memory.Span);
+        var segments = new CookieSegments(header.Span);
 
         while (segments.MoveNext())
         {
-            target.Add(new(new ByteString(memory[segments.Name]), new ByteString(memory[segments.Value])));
+            target.Add(new(header[segments.Name], header[segments.Value]));
         }
     }
 
@@ -164,12 +161,12 @@ public static class CookieHeaderExtensions
     /// A read-only list of cookies that have been parsed from one or
     /// more "Cookie" header values.
     /// </summary>
-    private sealed class CookieList(List<KeyValuePair<ByteString, ByteString>> entries) : IKeyValueList
+    private sealed class CookieList(List<KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>> entries) : IKeyValueList
     {
 
         public int Count => entries.Count;
 
-        public KeyValuePair<ByteString, ByteString> this[int index] => entries[index];
+        public KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> this[int index] => entries[index];
 
     }
 

--- a/API/Protocol/IRequestHeaders.Cookies.cs
+++ b/API/Protocol/IRequestHeaders.Cookies.cs
@@ -18,7 +18,7 @@ public static class CookieHeaderExtensions
     {
         for (var i = 0; i < headers.Count; i++)
         {
-            var entry = headers[i];
+            var entry = headers.GetMemoryEntry(i);
 
             if (entry.Key != KnownHeaders.Cookie)
             {
@@ -57,7 +57,7 @@ public static class CookieHeaderExtensions
 
         for (var i = 0; i < headers.Count; i++)
         {
-            var entry = headers[i];
+            var entry = headers.GetMemoryEntry(i);
 
             if (entry.Key == KnownHeaders.Cookie)
             {
@@ -166,7 +166,7 @@ public static class CookieHeaderExtensions
 
         public int Count => entries.Count;
 
-        public KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> this[int index] => entries[index];
+        public KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> GetMemoryEntry(int index) => entries[index];
 
     }
 

--- a/API/Protocol/IRequestHeaders.Forwarding.cs
+++ b/API/Protocol/IRequestHeaders.Forwarding.cs
@@ -28,7 +28,7 @@ public static class ForwardingHeaderExtensions
 
         for (var i = 0; i < headers.Count; i++)
         {
-            var entry = headers[i];
+            var entry = headers.GetStringEntry(i);
 
             if (entry.Key == KnownHeaders.Forwarded)
             {

--- a/Engine/Internal/Protocol/ResponseHandler.cs
+++ b/Engine/Internal/Protocol/ResponseHandler.cs
@@ -162,9 +162,9 @@ internal sealed class ResponseHandler
         {
             var header = headers[i];
 
-            writer.Write(header.Key.Bytes.Span);
+            writer.Write(header.Key.Span);
             writer.Write(": "u8);
-            writer.Write(header.Value.Bytes.Span);
+            writer.Write(header.Value.Span);
             writer.Write("\r\n"u8);
         }
     }

--- a/Engine/Internal/Protocol/ResponseHandler.cs
+++ b/Engine/Internal/Protocol/ResponseHandler.cs
@@ -160,7 +160,7 @@ internal sealed class ResponseHandler
 
         for (var i = 0; i < headers.Count; i++)
         {
-            var header = headers[i];
+            var header = headers.GetMemoryEntry(i);
 
             writer.Write(header.Key.Span);
             writer.Write(": "u8);

--- a/Engine/Ioxide/Protocol/ResponseWriter.cs
+++ b/Engine/Ioxide/Protocol/ResponseWriter.cs
@@ -120,7 +120,7 @@ internal static class ResponseWriter
 
         for (var i = 0; i < headers.Count; i++)
         {
-            var header = headers[i];
+            var header = headers.GetMemoryEntry(i);
 
             writer.Write(header.Key.Span);
             writer.Write(": "u8);

--- a/Engine/Ioxide/Protocol/ResponseWriter.cs
+++ b/Engine/Ioxide/Protocol/ResponseWriter.cs
@@ -122,9 +122,9 @@ internal static class ResponseWriter
         {
             var header = headers[i];
 
-            writer.Write(header.Key.Bytes.Span);
+            writer.Write(header.Key.Span);
             writer.Write(": "u8);
-            writer.Write(header.Value.Bytes.Span);
+            writer.Write(header.Value.Span);
             writer.Write("\r\n"u8);
         }
     }
@@ -162,4 +162,5 @@ internal static class ResponseWriter
         Utf8Formatter.TryFormat(value, span, out var written);
         writer.Advance(written);
     }
+
 }

--- a/Engine/Shared/Types/EditableKeyValueList.cs
+++ b/Engine/Shared/Types/EditableKeyValueList.cs
@@ -4,15 +4,15 @@ namespace GenHTTP.Engine.Shared.Types;
 
 public class EditableKeyValueList : IKeyValueList
 {
-    private readonly List<KeyValuePair<ByteString, ByteString>> _store = [];
+    private readonly List<KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>> _store = [];
 
     public int Count => _store.Count;
 
-    public KeyValuePair<ByteString, ByteString> this[int index] => _store[index];
+    public KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> this[int index] => _store[index];
 
     public void Add(ByteString key, ByteString value)
     {
-        _store.Add(new KeyValuePair<ByteString, ByteString>(key, value));
+        _store.Add(new KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(key.Bytes, value.Bytes));
     }
 
     public void Clear() => _store.Clear();

--- a/Engine/Shared/Types/EditableKeyValueList.cs
+++ b/Engine/Shared/Types/EditableKeyValueList.cs
@@ -8,7 +8,7 @@ public class EditableKeyValueList : IKeyValueList
 
     public int Count => _store.Count;
 
-    public KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> this[int index] => _store[index];
+    public KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> GetMemoryEntry(int index) => _store[index];
 
     public void Add(ByteString key, ByteString value)
     {

--- a/Engine/Shared/Types/KeyValueList.cs
+++ b/Engine/Shared/Types/KeyValueList.cs
@@ -8,6 +8,6 @@ public sealed class KeyValueList(Glyph.KeyValueList source) : IRequestHeaders, I
 
     public int Count => source.Count;
 
-    public KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> this [int index] => source[index];
+    public KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> GetMemoryEntry(int index) => source[index];
 
 }

--- a/Engine/Shared/Types/KeyValueList.cs
+++ b/Engine/Shared/Types/KeyValueList.cs
@@ -1,5 +1,4 @@
 ﻿using GenHTTP.Api.Protocol;
-
 using Glyph = Glyph11.Protocol;
 
 namespace GenHTTP.Engine.Shared.Types;
@@ -9,14 +8,6 @@ public sealed class KeyValueList(Glyph.KeyValueList source) : IRequestHeaders, I
 
     public int Count => source.Count;
 
-    public KeyValuePair<ByteString, ByteString> this[int index]
-    {
-        get
-        {
-            var kv = source[index];
-            
-            return new KeyValuePair<ByteString, ByteString>(new(kv.Key), new(kv.Value));
-        }
-    }
+    public KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> this [int index] => source[index];
 
 }

--- a/Engine/Shared/Types/RetainedKeyValueList.cs
+++ b/Engine/Shared/Types/RetainedKeyValueList.cs
@@ -4,7 +4,7 @@ namespace GenHTTP.Engine.Shared.Types;
 
 public class RetainedKeyValueList : IRequestHeaders, IRequestQuery
 {
-    private readonly List<KeyValuePair<ByteString, ByteString>> _items;
+    private readonly List<KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>> _items;
 
     public int Count => _items.Count;
 
@@ -15,11 +15,11 @@ public class RetainedKeyValueList : IRequestHeaders, IRequestQuery
         for (var i = 0; i < source.Count; i++)
         {
             var pair = source[i];
-            
-            _items.Add(new (new ByteString(pair.Key.Bytes.ToArray()), new ByteString(pair.Value.Bytes.ToArray())));
+
+            _items.Add(new (pair.Key.ToArray(), pair.Value.ToArray()));
         }
     }
 
-    public KeyValuePair<ByteString, ByteString> this[int index] => _items[index];
+    public KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> this[int index] => _items[index];
 
 }

--- a/Engine/Shared/Types/RetainedKeyValueList.cs
+++ b/Engine/Shared/Types/RetainedKeyValueList.cs
@@ -14,12 +14,12 @@ public class RetainedKeyValueList : IRequestHeaders, IRequestQuery
 
         for (var i = 0; i < source.Count; i++)
         {
-            var pair = source[i];
+            var pair = source.GetMemoryEntry(i);
 
             _items.Add(new (pair.Key.ToArray(), pair.Value.ToArray()));
         }
     }
 
-    public KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> this[int index] => _items[index];
+    public KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> GetMemoryEntry(int index) => _items[index];
 
 }

--- a/Generators/MemoryView/CodeEmitter.cs
+++ b/Generators/MemoryView/CodeEmitter.cs
@@ -100,17 +100,6 @@ internal static class CodeEmitter
         sb.AppendLine();
 
         sb.AppendLine($"{indent}[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
-        sb.AppendLine($"{indent}private static byte Normalize(byte value)");
-        sb.AppendLine($"{indent}{{");
-        sb.AppendLine($"{indent}    var lower = (byte)(value | 0x20);");
-        sb.AppendLine();
-        sb.AppendLine($"{indent}    return (uint)(lower - 'a') <= ('z' - 'a')");
-        sb.AppendLine($"{indent}        ? lower");
-        sb.AppendLine($"{indent}        : value;");
-        sb.AppendLine($"{indent}}}");
-        sb.AppendLine();
-
-        sb.AppendLine($"{indent}[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
         sb.AppendLine($"{indent}private static int ComputeHash(global::System.ReadOnlySpan<byte> span)");
         sb.AppendLine($"{indent}{{");
         sb.AppendLine($"{indent}    const uint Offset = 2166136261;");
@@ -120,7 +109,7 @@ internal static class CodeEmitter
         sb.AppendLine();
         sb.AppendLine($"{indent}    foreach (var b in span)");
         sb.AppendLine($"{indent}    {{");
-        sb.AppendLine($"{indent}        hash ^= Normalize(b);");
+        sb.AppendLine($"{indent}        hash ^= b;");
         sb.AppendLine($"{indent}        hash *= Prime;");
         sb.AppendLine($"{indent}    }}");
         sb.AppendLine();
@@ -138,70 +127,111 @@ internal static class CodeEmitter
         sb.AppendLine($"{indent}#region Equality");
         sb.AppendLine();
 
+        // ─────────────────────────────────────────────────────────────────────
+        // Generated type == Generated type
+        // ─────────────────────────────────────────────────────────────────────
+
         sb.AppendLine($"{indent}[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
         sb.AppendLine($"{indent}public bool Equals({info.TypeName} other)");
         sb.AppendLine($"{indent}{{");
+
+        // The hash includes the length and all bytes.
+        // A hash mismatch is therefore a very cheap rejection.
+        // SequenceEqual remains the definitive equality check.
         sb.AppendLine($"{indent}    if (_hash != other._hash)");
         sb.AppendLine($"{indent}    {{");
         sb.AppendLine($"{indent}        return false;");
         sb.AppendLine($"{indent}    }}");
         sb.AppendLine();
 
-        sb.AppendLine($"{indent}    var a = {FieldName}.Span;");
-        sb.AppendLine($"{indent}    var b = other.{FieldName}.Span;");
-        sb.AppendLine();
-
-        sb.AppendLine($"{indent}    if (a.Length != b.Length)");
-        sb.AppendLine($"{indent}    {{");
-        sb.AppendLine($"{indent}        return false;");
-        sb.AppendLine($"{indent}    }}");
-        sb.AppendLine();
-
-        // SIMD fast path
-        sb.AppendLine($"{indent}    if (a.SequenceEqual(b))");
-        sb.AppendLine($"{indent}    {{");
-        sb.AppendLine($"{indent}        return true;");
-        sb.AppendLine($"{indent}    }}");
-        sb.AppendLine();
-
-        // ASCII-insensitive fallback
-        sb.AppendLine($"{indent}    for (var i = 0; i < a.Length; i++)");
-        sb.AppendLine($"{indent}    {{");
-        sb.AppendLine($"{indent}        var ca = a[i];");
-        sb.AppendLine($"{indent}        var cb = b[i];");
-        sb.AppendLine();
-        sb.AppendLine($"{indent}        var la = Normalize(ca);");
-        sb.AppendLine($"{indent}        var lb = Normalize(cb);");
-        sb.AppendLine();
-        sb.AppendLine($"{indent}        if (la != lb)");
-        sb.AppendLine($"{indent}        {{");
-        sb.AppendLine($"{indent}            return false;");
-        sb.AppendLine($"{indent}        }}");
-        sb.AppendLine($"{indent}    }}");
-        sb.AppendLine();
-        sb.AppendLine($"{indent}    return true;");
+        sb.AppendLine($"{indent}    return {FieldName}.Span.SequenceEqual(other.{FieldName}.Span);");
         sb.AppendLine($"{indent}}}");
         sb.AppendLine();
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Generated type == ReadOnlyMemory<byte>
+        // ─────────────────────────────────────────────────────────────────────
+
+        sb.AppendLine($"{indent}[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
+        sb.AppendLine($"{indent}public bool Equals(global::System.ReadOnlyMemory<byte> other)");
+        sb.AppendLine($"{indent}    => {FieldName}.Span.SequenceEqual(other.Span);");
+        sb.AppendLine();
+
+        // ─────────────────────────────────────────────────────────────────────
+        // object.Equals
+        // ─────────────────────────────────────────────────────────────────────
 
         sb.AppendLine($"{indent}[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
         sb.AppendLine($"{indent}public override bool Equals(object? obj)");
         sb.AppendLine($"{indent}    => obj is {info.TypeName} other && Equals(other);");
         sb.AppendLine();
 
+        // ─────────────────────────────────────────────────────────────────────
+        // GetHashCode
+        // ─────────────────────────────────────────────────────────────────────
+
         sb.AppendLine($"{indent}[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
         sb.AppendLine($"{indent}public override int GetHashCode() => _hash;");
         sb.AppendLine();
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Generated type == Generated type
+        // ─────────────────────────────────────────────────────────────────────
 
         sb.AppendLine($"{indent}[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
         sb.AppendLine($"{indent}public static bool operator ==({info.TypeName} left, {info.TypeName} right)");
         sb.AppendLine($"{indent}    => left.Equals(right);");
         sb.AppendLine();
 
+        // ─────────────────────────────────────────────────────────────────────
+        // Generated type != Generated type
+        // ─────────────────────────────────────────────────────────────────────
+
         sb.AppendLine($"{indent}[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
         sb.AppendLine($"{indent}public static bool operator !=({info.TypeName} left, {info.TypeName} right)");
         sb.AppendLine($"{indent}    => !left.Equals(right);");
-
         sb.AppendLine();
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Generated type == ReadOnlyMemory<byte>
+        // ─────────────────────────────────────────────────────────────────────
+
+        sb.AppendLine($"{indent}[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
+        sb.AppendLine($"{indent}public static bool operator ==({info.TypeName} left, global::System.ReadOnlyMemory<byte> right)");
+        sb.AppendLine($"{indent}    => left.Equals(right);");
+        sb.AppendLine();
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Generated type != ReadOnlyMemory<byte>
+        // ─────────────────────────────────────────────────────────────────────
+
+        sb.AppendLine($"{indent}[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
+        sb.AppendLine($"{indent}public static bool operator !=({info.TypeName} left, global::System.ReadOnlyMemory<byte> right)");
+        sb.AppendLine($"{indent}    => !left.Equals(right);");
+        sb.AppendLine();
+
+        // ─────────────────────────────────────────────────────────────────────
+        // ReadOnlyMemory<byte> == Generated type
+        // ─────────────────────────────────────────────────────────────────────
+
+        sb.AppendLine($"{indent}[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
+        sb.AppendLine($"{indent}public static bool operator ==(global::System.ReadOnlyMemory<byte> left, {info.TypeName} right)");
+        sb.AppendLine($"{indent}    => right.Equals(left);");
+        sb.AppendLine();
+
+        // ─────────────────────────────────────────────────────────────────────
+        // ReadOnlyMemory<byte> != Generated type
+        // ─────────────────────────────────────────────────────────────────────
+
+        sb.AppendLine($"{indent}[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
+        sb.AppendLine($"{indent}public static bool operator !=(global::System.ReadOnlyMemory<byte> left, {info.TypeName} right)");
+        sb.AppendLine($"{indent}    => !right.Equals(left);");
+        sb.AppendLine();
+
+        // ─────────────────────────────────────────────────────────────────────
+        // String representation
+        // ─────────────────────────────────────────────────────────────────────
+
         sb.AppendLine($"{indent}public override string ToString()");
         sb.AppendLine($"{indent}    => global::System.Text.Encoding.ASCII.GetString({FieldName}.Span);");
         sb.AppendLine();
@@ -216,5 +246,4 @@ internal static class CodeEmitter
 
         return sb.ToString();
     }
-
 }

--- a/Generators/MemoryView/CodeEmitter.cs
+++ b/Generators/MemoryView/CodeEmitter.cs
@@ -99,6 +99,25 @@ internal static class CodeEmitter
         sb.AppendLine($"{indent}#region Helpers");
         sb.AppendLine();
 
+        // ─────────────────────────────────────────────────────────────────────
+        // ASCII normalization
+        // ─────────────────────────────────────────────────────────────────────
+
+        sb.AppendLine($"{indent}[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
+        sb.AppendLine($"{indent}private static byte Normalize(byte value)");
+        sb.AppendLine($"{indent}{{");
+        sb.AppendLine($"{indent}    var lower = (byte)(value | 0x20);");
+        sb.AppendLine();
+        sb.AppendLine($"{indent}    return (uint)(lower - 'a') <= ('z' - 'a')");
+        sb.AppendLine($"{indent}        ? lower");
+        sb.AppendLine($"{indent}        : value;");
+        sb.AppendLine($"{indent}}}");
+        sb.AppendLine();
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Case-insensitive hash
+        // ─────────────────────────────────────────────────────────────────────
+
         sb.AppendLine($"{indent}[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
         sb.AppendLine($"{indent}private static int ComputeHash(global::System.ReadOnlySpan<byte> span)");
         sb.AppendLine($"{indent}{{");
@@ -109,11 +128,45 @@ internal static class CodeEmitter
         sb.AppendLine();
         sb.AppendLine($"{indent}    foreach (var b in span)");
         sb.AppendLine($"{indent}    {{");
-        sb.AppendLine($"{indent}        hash ^= b;");
+        sb.AppendLine($"{indent}        hash ^= Normalize(b);");
         sb.AppendLine($"{indent}        hash *= Prime;");
         sb.AppendLine($"{indent}    }}");
         sb.AppendLine();
         sb.AppendLine($"{indent}    return (int)hash;");
+        sb.AppendLine($"{indent}}}");
+        sb.AppendLine();
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Case-insensitive memory comparison
+        // ─────────────────────────────────────────────────────────────────────
+
+        sb.AppendLine($"{indent}[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
+        sb.AppendLine($"{indent}private static bool EqualsIgnoreCase(global::System.ReadOnlySpan<byte> a, global::System.ReadOnlySpan<byte> b)");
+        sb.AppendLine($"{indent}{{");
+        sb.AppendLine($"{indent}    if (a.Length != b.Length)");
+        sb.AppendLine($"{indent}    {{");
+        sb.AppendLine($"{indent}        return false;");
+        sb.AppendLine($"{indent}    }}");
+        sb.AppendLine();
+
+        // Exact equality is by far the cheapest successful path.
+        // SequenceEqual is vectorized by the runtime where supported.
+        sb.AppendLine($"{indent}    if (a.SequenceEqual(b))");
+        sb.AppendLine($"{indent}    {{");
+        sb.AppendLine($"{indent}        return true;");
+        sb.AppendLine($"{indent}    }}");
+        sb.AppendLine();
+
+        // Only normalize when exact equality failed.
+        sb.AppendLine($"{indent}    for (var i = 0; i < a.Length; i++)");
+        sb.AppendLine($"{indent}    {{");
+        sb.AppendLine($"{indent}        if (Normalize(a[i]) != Normalize(b[i]))");
+        sb.AppendLine($"{indent}        {{");
+        sb.AppendLine($"{indent}            return false;");
+        sb.AppendLine($"{indent}        }}");
+        sb.AppendLine($"{indent}    }}");
+        sb.AppendLine();
+        sb.AppendLine($"{indent}    return true;");
         sb.AppendLine($"{indent}}}");
 
         sb.AppendLine();
@@ -135,16 +188,15 @@ internal static class CodeEmitter
         sb.AppendLine($"{indent}public bool Equals({info.TypeName} other)");
         sb.AppendLine($"{indent}{{");
 
-        // The hash includes the length and all bytes.
-        // A hash mismatch is therefore a very cheap rejection.
-        // SequenceEqual remains the definitive equality check.
+        // The hash is computed using the same case-insensitive normalization
+        // as the equality comparison.
         sb.AppendLine($"{indent}    if (_hash != other._hash)");
         sb.AppendLine($"{indent}    {{");
         sb.AppendLine($"{indent}        return false;");
         sb.AppendLine($"{indent}    }}");
         sb.AppendLine();
 
-        sb.AppendLine($"{indent}    return {FieldName}.Span.SequenceEqual(other.{FieldName}.Span);");
+        sb.AppendLine($"{indent}    return EqualsIgnoreCase({FieldName}.Span, other.{FieldName}.Span);");
         sb.AppendLine($"{indent}}}");
         sb.AppendLine();
 
@@ -154,7 +206,7 @@ internal static class CodeEmitter
 
         sb.AppendLine($"{indent}[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
         sb.AppendLine($"{indent}public bool Equals(global::System.ReadOnlyMemory<byte> other)");
-        sb.AppendLine($"{indent}    => {FieldName}.Span.SequenceEqual(other.Span);");
+        sb.AppendLine($"{indent}    => EqualsIgnoreCase({FieldName}.Span, other.Span);");
         sb.AppendLine();
 
         // ─────────────────────────────────────────────────────────────────────

--- a/Modules/IO/BodyArguments.cs
+++ b/Modules/IO/BodyArguments.cs
@@ -8,7 +8,7 @@ namespace GenHTTP.Modules.IO;
 /// </summary>
 public sealed class BodyArguments : IKeyValueList
 {
-    private readonly KeyValuePair<ByteString, ByteString>[] _entries;
+    private readonly KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>[] _entries;
 
     #region Initialization
 
@@ -17,7 +17,7 @@ public sealed class BodyArguments : IKeyValueList
     /// </summary>
     public static readonly BodyArguments Empty = new([]);
 
-    private BodyArguments(KeyValuePair<ByteString, ByteString>[] entries)
+    private BodyArguments(KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>[] entries)
     {
         _entries = entries;
     }
@@ -40,7 +40,7 @@ public sealed class BodyArguments : IKeyValueList
 
     public int Count => _entries.Length;
 
-    public KeyValuePair<ByteString, ByteString> this[int index] => _entries[index];
+    public KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> this[int index] => _entries[index];
 
     #endregion
 
@@ -53,7 +53,7 @@ public sealed class BodyArguments : IKeyValueList
             return Empty;
         }
 
-        var entries = new List<KeyValuePair<ByteString, ByteString>>();
+        var entries = new List<KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>>();
 
         var remaining = memory;
 
@@ -74,7 +74,7 @@ public sealed class BodyArguments : IKeyValueList
         return new BodyArguments(entries.ToArray());
     }
 
-    private static KeyValuePair<ByteString, ByteString> ParsePair(ReadOnlyMemory<byte> pair)
+    private static KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> ParsePair(ReadOnlyMemory<byte> pair)
     {
         var separator = pair.Span.IndexOf((byte)'=');
 
@@ -86,20 +86,20 @@ public sealed class BodyArguments : IKeyValueList
     /// Decodes a percent- and "+"-encoded token, only allocating a new
     /// buffer if the token actually requires decoding.
     /// </summary>
-    private static ByteString Decode(ReadOnlyMemory<byte> raw)
+    private static ReadOnlyMemory<byte> Decode(ReadOnlyMemory<byte> raw)
     {
         var source = raw.Span;
 
         if (source.IndexOfAny((byte)'%', (byte)'+') < 0)
         {
-            return new ByteString(raw);
+            return raw;
         }
 
         var target = new byte[source.Length];
 
         var written = PercentEncoding.Decode(source, target, decodePlus: true);
 
-        return new ByteString(target.AsMemory(0, written));
+        return target.AsMemory(0, written);
     }
 
     #endregion

--- a/Modules/IO/BodyArguments.cs
+++ b/Modules/IO/BodyArguments.cs
@@ -40,7 +40,7 @@ public sealed class BodyArguments : IKeyValueList
 
     public int Count => _entries.Length;
 
-    public KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> this[int index] => _entries[index];
+    public KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> GetMemoryEntry(int index) => _entries[index];
 
     #endregion
 

--- a/Modules/Inspection/Concern/InspectionConcern.cs
+++ b/Modules/Inspection/Concern/InspectionConcern.cs
@@ -119,7 +119,7 @@ public sealed class InspectionConcern : IConcern
 
         for (var i = 0; i < list.Count; i++)
         {
-            var entry = list[i];
+            var entry = list.GetStringEntry(i);
 
             result.Add(new(entry.Key.ToString(), entry.Value.ToString()));
         }

--- a/Modules/ReverseProxy/Http/HttpProxy.cs
+++ b/Modules/ReverseProxy/Http/HttpProxy.cs
@@ -93,7 +93,7 @@ public sealed class HttpProxy : IHandler
 
         for (var i = 0; i < headers.Count; i++)
         {
-            var header = headers[i];
+            var header = headers.GetStringEntry(i);
 
             var key = header.Key.ToString();
             var value = header.Value.ToString();
@@ -151,7 +151,7 @@ public sealed class HttpProxy : IHandler
 
             for (var i = 0; i < query.Count; i++)
             {
-                var arg = query[i];
+                var arg = query.GetStringEntry(i);
 
                 var key = arg.Key.ToString();
                 var value= HttpUtility.UrlDecode(arg.Value.ToString());

--- a/Modules/ReverseProxy/Websocket/RawWebsocketConnection.cs
+++ b/Modules/ReverseProxy/Websocket/RawWebsocketConnection.cs
@@ -101,10 +101,10 @@ public sealed class RawWebsocketConnection : IAsyncDisposable
         writer.Write(_route.Span);
         writer.Write(" HTTP/1.1"u8);
         writer.Write(_clrf.Span);
-        
+
         writer.Write("Host: "u8);
         writer.Write(Encoding.ASCII.GetBytes(_host));
-        
+
         if (!_isDefaultPort)
         {
             writer.Write(":"u8);
@@ -125,9 +125,9 @@ public sealed class RawWebsocketConnection : IAsyncDisposable
             if (key == KnownHeaders.Host)
                 continue;
 
-            writer.Write(key.Bytes.Span);
+            writer.Write(key.Span);
             writer.Write(":"u8);
-            writer.Write(value.Bytes.Span);
+            writer.Write(value.Span);
             writer.Write(_clrf.Span);
         }
 

--- a/Modules/ReverseProxy/Websocket/RawWebsocketConnection.cs
+++ b/Modules/ReverseProxy/Websocket/RawWebsocketConnection.cs
@@ -117,7 +117,7 @@ public sealed class RawWebsocketConnection : IAsyncDisposable
 
         for (var i = 0; i < headers.Count; i++)
         {
-            var header = headers[i];
+            var header = headers.GetMemoryEntry(i);
 
             var key = header.Key;
             var value = header.Value;

--- a/Testing/Acceptance/Api/ByteStringTests.cs
+++ b/Testing/Acceptance/Api/ByteStringTests.cs
@@ -1,0 +1,171 @@
+﻿using System.Text;
+
+using GenHTTP.Api.Protocol;
+
+namespace GenHTTP.Testing.Acceptance.Api;
+
+[TestClass]
+public sealed class ByteStringTests
+{
+
+    [TestMethod]
+    public void StringAndMemoryConstructors_CreateEqualValues()
+    {
+        var fromString = new ByteString("Content-Type");
+        var fromMemory = new ByteString(Encoding.ASCII.GetBytes("Content-Type"));
+
+        Assert.AreEqual(fromString, fromMemory);
+        Assert.AreEqual("Content-Type", fromString.ToString());
+    }
+
+    [TestMethod]
+    public void Equality_IsCaseInsensitive()
+    {
+        var lower = new ByteString("Content-Type");
+        var upper = new ByteString("CONTENT-TYPE");
+        var mixed = new ByteString("CoNtEnT-TyPe");
+
+        Assert.IsTrue(lower == upper);
+        Assert.IsTrue(lower.Equals(mixed));
+        Assert.IsFalse(lower != upper);
+    }
+
+    [TestMethod]
+    public void Equality_DifferentValuesAreNotEqual()
+    {
+        var first = new ByteString("Content-Type");
+        var second = new ByteString("Content-Length");
+
+        Assert.IsFalse(first == second);
+        Assert.IsTrue(first != second);
+        Assert.IsFalse(first.Equals(second));
+    }
+
+    [TestMethod]
+    public void Equality_WithReadOnlyMemory_IsCaseInsensitive()
+    {
+        var value = new ByteString("Content-Type");
+        ReadOnlyMemory<byte> memory =
+            Encoding.ASCII.GetBytes("CONTENT-TYPE");
+
+        Assert.IsTrue(value == memory);
+        Assert.IsTrue(memory == value);
+        Assert.IsFalse(value != memory);
+        Assert.IsFalse(memory != value);
+        Assert.IsTrue(value.Equals(memory));
+    }
+
+    [TestMethod]
+    public void Equality_WithReadOnlyMemory_DifferentValueIsNotEqual()
+    {
+        var value = new ByteString("Content-Type");
+        ReadOnlyMemory<byte> memory =
+            Encoding.ASCII.GetBytes("Content-Length");
+
+        Assert.IsFalse(value == memory);
+        Assert.IsFalse(memory == value);
+        Assert.IsTrue(value != memory);
+        Assert.IsTrue(memory != value);
+    }
+
+    [TestMethod]
+    public void EqualValues_HaveEqualHashCodes()
+    {
+        var lower = new ByteString("Content-Type");
+        var upper = new ByteString("CONTENT-TYPE");
+
+        Assert.AreEqual(
+            lower.GetHashCode(),
+            upper.GetHashCode());
+    }
+
+    [TestMethod]
+    public void Dictionary_IsCaseInsensitive()
+    {
+        var dictionary = new Dictionary<ByteString, string>
+        {
+            [new ByteString("Content-Type")] = "text/plain"
+        };
+
+        Assert.AreEqual(
+            "text/plain",
+            dictionary[new ByteString("content-type")]);
+
+        Assert.IsTrue(
+            dictionary.ContainsKey(new ByteString("CONTENT-TYPE")));
+    }
+
+    [TestMethod]
+    public void Dictionary_DifferentCasingDoesNotCreateDuplicateKey()
+    {
+        var dictionary = new Dictionary<ByteString, int>
+        {
+            [new ByteString("Subdir")] = 1
+        };
+
+        dictionary[new ByteString("SUBDIR")] = 2;
+
+        Assert.AreEqual(1, dictionary.Count);
+        Assert.AreEqual(2, dictionary[new ByteString("subdir")]);
+    }
+
+    [TestMethod]
+    public void HashSet_IsCaseInsensitive()
+    {
+        var set = new HashSet<ByteString>
+        {
+            new ByteString("Subdir")
+        };
+
+        Assert.IsTrue(set.Contains(new ByteString("SUBDIR")));
+        Assert.IsFalse(set.Add(new ByteString("subdir")));
+        Assert.AreEqual(1, set.Count);
+    }
+
+    [TestMethod]
+    public void ObjectAndGenericEquality_AreCaseInsensitive()
+    {
+        var value = new ByteString("Subdir");
+
+        object other = new ByteString("SUBDIR");
+        IEquatable<ByteString> equatable = value;
+
+        Assert.IsTrue(value.Equals(other));
+        Assert.IsTrue(equatable.Equals(new ByteString("SUBDIR")));
+    }
+
+    [TestMethod]
+    public void ReadOnlyMemorySlice_IsComparedUsingVisibleRange()
+    {
+        var bytes = Encoding.ASCII.GetBytes("xxxCONTENT-TYPExxx");
+
+        ReadOnlyMemory<byte> slice =
+            bytes.AsMemory(3, "CONTENT-TYPE".Length);
+
+        var value = new ByteString("content-type");
+
+        Assert.IsTrue(value == slice);
+        Assert.IsTrue(slice == value);
+    }
+
+    [TestMethod]
+    public void EmptyValues_AreEqual()
+    {
+        var value = new ByteString(string.Empty);
+
+        Assert.IsTrue(value == new ByteString(ReadOnlyMemory<byte>.Empty));
+        Assert.IsTrue(value == ReadOnlyMemory<byte>.Empty);
+        Assert.IsTrue(ReadOnlyMemory<byte>.Empty == value);
+    }
+
+    [TestMethod]
+    public void EqualityAndInequality_AreConsistent()
+    {
+        var equal = new ByteString("Subdir");
+        var same = new ByteString("SUBDIR");
+        var different = new ByteString("Other");
+
+        Assert.AreEqual(equal == same, ! (equal != same));
+        Assert.AreEqual(equal == different, !(equal != different));
+    }
+}

--- a/Testing/Acceptance/Engine/CookieTests.cs
+++ b/Testing/Acceptance/Engine/CookieTests.cs
@@ -68,7 +68,7 @@ public sealed class CookieTests
 
             for (var i = 0; i < list.Count; i++)
             {
-                var entry = list[i];
+                var entry = list.GetStringEntry(i);
 
                 cookies.Add((entry.Key.ToString(), entry.Value.ToString()));
             }

--- a/Testing/Acceptance/Engine/ParserTests.cs
+++ b/Testing/Acceptance/Engine/ParserTests.cs
@@ -106,21 +106,21 @@ public sealed class ParserTests
         public ValueTask<IResponse?> HandleAsync(IRequest request)
         {
             // todo: make this logic block reusable
-            
+
             var entries = new List<string>();
-            
+
             for (var i = 0; i < request.Header.Query.Count; i++)
             {
-                var entry = request.Header.Query[i];
+                var entry = request.Header.Query.GetStringEntry(i);
 
                 var key = HttpUtility.UrlDecode(entry.Key.ToString());
                 var value = HttpUtility.UrlDecode(entry.Value.ToString());
-                
+
                 entries.Add($"{key}={value}");
             }
-            
+
             var result = string.Join('|', entries);
-            
+
             return request.Respond()
                           .Content(result)
                           .BuildTask();

--- a/Testing/Acceptance/Modules/ReverseProxy/ReverseProxyTests.cs
+++ b/Testing/Acceptance/Modules/ReverseProxy/ReverseProxyTests.cs
@@ -202,14 +202,14 @@ public sealed class ReverseProxyTests
 
             for (var i = 0; i < r.Header.Query.Count; i++)
             {
-                var entry = r.Header.Query[i];
+                var entry = r.Header.Query.GetStringEntry(i);
 
                 var key = entry.Key.ToString();
                 var value = entry.Value.ToString();
-                
+
                 entries.Add($"{key}={value}");
             }
-            
+
             var result = string.Join('|', entries);
             return r.Respond().Content(result).Build();
         });
@@ -235,16 +235,16 @@ public sealed class ReverseProxyTests
 
             for (var i = 0; i < r.Header.Query.Count; i++)
             {
-                var entry = r.Header.Query[i];
+                var entry = r.Header.Query.GetStringEntry(i);
 
                 var key = entry.Key.ToString();
                 var value = HttpUtility.UrlDecode(entry.Value.ToString());
-                
+
                 entries.Add($"{key}={value}");
             }
-            
+
             var result = string.Join('|', entries);
-            
+
             return r.Respond().Content(result).Build();
         });
 


### PR DESCRIPTION
This should eliminate the performance regression introduced in preview 19.

Allows access via `.GetMemory(i)` or `.GetByteStrings(i)` to allow performance in the hot path where it is needed.

Also adds convenience operators to compare with `ReadOnlyMemory<byte>` via `==` and `!=`.