### PR TITLE
Feature/h3 experimental engine

### DIFF
--- a/Engine/Internal/Protocol/ClientHandler.cs
+++ b/Engine/Internal/Protocol/ClientHandler.cs
@@ -2,6 +2,7 @@
 using System.IO.Pipelines;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
+using System.Text;
 using GenHTTP.Api.Protocol;
 using GenHTTP.Engine.Internal.Context;
 using GenHTTP.Engine.Shared.Types;
@@ -28,7 +29,7 @@ internal sealed class ClientHandler(ClientContext context)
 
     private static readonly TimeSpan KeepAliveTimeout = TimeSpan.FromSeconds(60);
 
-    private static readonly ReadOnlyMemory<byte> KeepAliveValue = "Keep-Alive"u8.ToArray();
+    private static readonly ReadOnlyMemory<byte> KeepAliveValue = "keep-alive"u8.ToArray();
 
     private static readonly ParserLimits Limits = ParserLimits.Default;
 
@@ -203,7 +204,12 @@ internal sealed class ClientHandler(ClientContext context)
 
         var connectionHeader = header.Headers.GetEntry(KnownHeaders.Connection);
 
-        var keepAliveRequested = connectionHeader?.Bytes.Span.SequenceEqual(KeepAliveValue.Span) ?? (header.Protocol == HttpProtocol.Http11);
+        // Connection options are case-insensitive tokens (RFC 9110 7.6.1). Matching them exactly
+        // read a browser, which sends "keep-alive" in lower case, as asking to close - so every
+        // browser request got a new connection, and a new TLS handshake with it.
+        var keepAliveRequested = connectionHeader is { } connection
+            ? Ascii.EqualsIgnoreCase(connection.Bytes.Span, KeepAliveValue.Span)
+            : header.Protocol == HttpProtocol.Http11;
 
         var response = await context.Server.Handler.HandleAsync(request) ?? throw new InvalidOperationException("The root request handler did not return a response");
 

--- a/Engine/InternalH3Experimental/AltSvc.cs
+++ b/Engine/InternalH3Experimental/AltSvc.cs
@@ -1,0 +1,97 @@
+using GenHTTP.Api.Content;
+using GenHTTP.Api.Infrastructure;
+using GenHTTP.Api.Protocol;
+
+namespace GenHTTP.Engine.InternalH3Experimental;
+
+/// <summary>
+/// Advertises an HTTP/3 endpoint from a server that speaks HTTP/1.1 or HTTP/2.
+/// </summary>
+/// <remarks>
+/// Browsers never start on HTTP/3. They connect over TCP, and only try QUIC once a response has
+/// told them where to find it (RFC 7838). Without this header the HTTP/3 endpoint is reachable by
+/// clients told to use it explicitly, and by nobody else.
+///
+/// <para>Two things stop it working, both silently: the advertisement is only honoured when it
+/// arrives over TLS, and the certificate on the HTTP/3 port must be valid for the ORIGIN's host
+/// name. A wrong port produces no error at all, the browser simply keeps using HTTP/1.1.</para>
+/// </remarks>
+public sealed class AltSvcConcern : IConcern
+{
+    private readonly ByteString _value;
+
+    public IHandler Content { get; }
+
+    public AltSvcConcern(IHandler content, ushort port, uint maxAge)
+    {
+        Content = content;
+        _value = new ByteString($"h3=\":{port}\"; ma={maxAge}");
+    }
+
+    public ValueTask PrepareAsync(IServer server) => Content.PrepareAsync(server);
+
+    public async ValueTask<IResponse?> HandleAsync(IRequest request)
+    {
+        IResponse? response = await Content.HandleAsync(request);
+
+        // Pointless on a connection that is already HTTP/3, and ignored by clients anyway.
+        if (response is not null && request.Header.Protocol != HttpProtocol.Http3)
+        {
+            response.Rebuild().Header(AltSvcName, _value);
+        }
+
+        return response;
+    }
+
+    private static readonly ByteString AltSvcName = new("alt-svc");
+}
+
+/// <summary>
+/// Builder for <see cref="AltSvcConcern"/>.
+/// </summary>
+public sealed class AltSvcConcernBuilder : IConcernBuilder
+{
+    private ushort _port = 443;
+
+    private uint _maxAge = 86400;
+
+    /// <summary>
+    /// The UDP port the HTTP/3 endpoint listens on. Must match what that server bound, or clients
+    /// silently never upgrade.
+    /// </summary>
+    public AltSvcConcernBuilder Port(ushort port)
+    {
+        _port = port;
+        return this;
+    }
+
+    /// <summary>How long a client may cache the advertisement, in seconds.</summary>
+    public AltSvcConcernBuilder MaxAge(uint seconds)
+    {
+        _maxAge = seconds;
+        return this;
+    }
+
+    public IConcern Build(IHandler content) => new AltSvcConcern(content, _port, _maxAge);
+}
+
+/// <summary>
+/// Advertises an HTTP/3 endpoint to clients arriving over TCP.
+/// </summary>
+public static class AltSvc
+{
+
+    /// <summary>
+    /// Adds an <c>Alt-Svc</c> header pointing at an HTTP/3 endpoint on the given UDP port.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var h1 = GenHTTP.Engine.Internal.Host.Create()
+    ///                 .Handler(app)
+    ///                 .Add(AltSvc.To(443))
+    ///                 .Bind(IPAddress.Any, 443, certificate);
+    /// </code>
+    /// </example>
+    public static AltSvcConcernBuilder To(ushort port) => new AltSvcConcernBuilder().Port(port);
+
+}

--- a/Engine/InternalH3Experimental/GenHTTP.Engine.InternalH3Experimental.csproj
+++ b/Engine/InternalH3Experimental/GenHTTP.Engine.InternalH3Experimental.csproj
@@ -18,7 +18,7 @@
 
         <ProjectReference Include="..\Shared\GenHTTP.Engine.Shared.csproj" />
 
-        <PackageReference Include="Glyph3" Version="0.3.0" />
+        <PackageReference Include="Glyph3" Version="0.11.652" />
 
     </ItemGroup>
 

--- a/Engine/InternalH3Experimental/GenHTTP.Engine.InternalH3Experimental.csproj
+++ b/Engine/InternalH3Experimental/GenHTTP.Engine.InternalH3Experimental.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+
+        <Description>EXPERIMENTAL HTTP/3 engine for GenHTTP: QUIC via System.Net.Quic (MsQuic), HTTP/3 via Glyph3. Runs alongside another engine that serves HTTP/1.1 and advertises this one with Alt-Svc.</Description>
+        <PackageTags>GenHTTP HTTP HTTP3 H3 QUIC Webserver Server Library C# Engine Experimental</PackageTags>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+
+        <!-- System.Net.Quic is annotated as linux/macOS/windows only, and the analyzer cannot see
+             the QuicListener.IsSupported check this engine makes before touching any of it. -->
+        <NoWarn>$(NoWarn);CA1416</NoWarn>
+
+    </PropertyGroup>
+
+    <ItemGroup>
+
+        <ProjectReference Include="..\..\API\GenHTTP.Api.csproj" />
+
+        <ProjectReference Include="..\Shared\GenHTTP.Engine.Shared.csproj" />
+
+        <PackageReference Include="Glyph3" Version="0.1.0" />
+
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="README.md" Pack="true" PackagePath="" />
+    </ItemGroup>
+
+</Project>

--- a/Engine/InternalH3Experimental/GenHTTP.Engine.InternalH3Experimental.csproj
+++ b/Engine/InternalH3Experimental/GenHTTP.Engine.InternalH3Experimental.csproj
@@ -18,7 +18,7 @@
 
         <ProjectReference Include="..\Shared\GenHTTP.Engine.Shared.csproj" />
 
-        <PackageReference Include="Glyph3" Version="0.1.0" />
+        <PackageReference Include="Glyph3" Version="0.3.0" />
 
     </ItemGroup>
 

--- a/Engine/InternalH3Experimental/GenHTTP.Engine.InternalH3Experimental.csproj
+++ b/Engine/InternalH3Experimental/GenHTTP.Engine.InternalH3Experimental.csproj
@@ -18,7 +18,7 @@
 
         <ProjectReference Include="..\Shared\GenHTTP.Engine.Shared.csproj" />
 
-        <PackageReference Include="Glyph3" Version="0.11.652" />
+        <PackageReference Include="Glyph3" Version="0.12.0" />
 
     </ItemGroup>
 

--- a/Engine/InternalH3Experimental/Host.cs
+++ b/Engine/InternalH3Experimental/Host.cs
@@ -1,0 +1,26 @@
+using GenHTTP.Api.Infrastructure;
+
+using GenHTTP.Engine.InternalH3Experimental.Infrastructure;
+
+namespace GenHTTP.Engine.InternalH3Experimental;
+
+/// <summary>
+/// Entry point to host an application over HTTP/3.
+/// </summary>
+/// <remarks>
+/// EXPERIMENTAL. QUIC comes from System.Net.Quic, which needs libmsquic present: Windows ships it
+/// with the .NET runtime, Linux and macOS install it separately. HTTP/3 comes from Glyph3.
+///
+/// <para>Browsers do not reach HTTP/3 directly. They connect over HTTP/1.1 or HTTP/2 first and
+/// only try QUIC once a server advertises it, so this engine is meant to run beside one that
+/// serves TCP. See <see cref="AltSvc"/>.</para>
+/// </remarks>
+public static class Host
+{
+
+    /// <summary>
+    /// Provides a new server host serving HTTP/3 over QUIC.
+    /// </summary>
+    public static IServerHost Create() => new H3ServerHost();
+
+}

--- a/Engine/InternalH3Experimental/Host.cs
+++ b/Engine/InternalH3Experimental/Host.cs
@@ -21,6 +21,16 @@ public static class Host
     /// <summary>
     /// Provides a new server host serving HTTP/3 over QUIC.
     /// </summary>
-    public static IServerHost Create() => new H3ServerHost();
+    /// <param name="qpackDynamicTableCapacity">
+    /// Bytes of QPACK dynamic table advertised to clients, and the ceiling on what this server will
+    /// use for its own responses. 0 (the default) switches the mechanism off: headers are encoded
+    /// with the static table and literals only.
+    ///
+    /// A nonzero value lets a client compress headers it repeats - cookies and user-agent, mostly -
+    /// to about two bytes each. Most clients decline: curl, and .NET's own HTTP/3 client, advertise
+    /// no table at all. Browsers are the ones that may use it.
+    /// </param>
+    public static IServerHost Create(int qpackDynamicTableCapacity = 0)
+        => new H3ServerHost(qpackDynamicTableCapacity);
 
 }

--- a/Engine/InternalH3Experimental/Infrastructure/H3Server.cs
+++ b/Engine/InternalH3Experimental/Infrastructure/H3Server.cs
@@ -35,8 +35,12 @@ internal sealed class H3Server : IServer
 
     internal ServerConfiguration Configuration { get; }
 
-    internal H3Server(ServerConfiguration configuration, IHandler handler)
+    internal int QpackCapacity { get; }
+
+    internal H3Server(ServerConfiguration configuration, IHandler handler, int qpackCapacity)
     {
+        QpackCapacity = qpackCapacity;
+
         Version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "(n/a)";
 
         Configuration = configuration;

--- a/Engine/InternalH3Experimental/Infrastructure/H3Server.cs
+++ b/Engine/InternalH3Experimental/Infrastructure/H3Server.cs
@@ -1,0 +1,89 @@
+using System.Diagnostics;
+using System.Reflection;
+
+using GenHTTP.Api.Content;
+using GenHTTP.Api.Infrastructure;
+
+using GenHTTP.Engine.Shared.Infrastructure;
+using GenHTTP.Engine.Shared.Types;
+
+using Microsoft.Extensions.Logging;
+
+namespace GenHTTP.Engine.InternalH3Experimental.Infrastructure;
+
+internal sealed class H3Server : IServer
+{
+    private readonly QuicEndPointCollection _endPoints;
+
+    private readonly PropertyBag _properties = new();
+
+    private readonly ILogger _logger;
+
+    public string Version { get; }
+
+    public bool Running => !_disposed;
+
+    public bool Development => Configuration.DevelopmentMode;
+
+    public IHandler Handler { get; }
+
+    public IPropertyBag Properties => _properties;
+
+    public ILoggerFactory Logging => Configuration.Logging;
+
+    public IEndPointCollection EndPoints => _endPoints;
+
+    internal ServerConfiguration Configuration { get; }
+
+    internal H3Server(ServerConfiguration configuration, IHandler handler)
+    {
+        Version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "(n/a)";
+
+        Configuration = configuration;
+
+        Handler = handler;
+
+        _logger = configuration.Logging.CreateLogger<H3Server>();
+
+        _endPoints = new QuicEndPointCollection(this, configuration.EndPoints);
+    }
+
+    public async ValueTask StartAsync()
+    {
+        await PrepareHandlerAsync(Handler);
+
+        await _endPoints.StartAsync();
+    }
+
+    private async ValueTask PrepareHandlerAsync(IHandler handler)
+    {
+        try
+        {
+            var start = Stopwatch.GetTimestamp();
+
+            await handler.PrepareAsync(this);
+
+            var elapsed = Stopwatch.GetElapsedTime(start);
+
+            _logger.LogInformation("Prepared handlers in {ElapsedMs:0.##} ms", elapsed.TotalMilliseconds);
+        }
+        catch (Exception e)
+        {
+            _logger.LogCritical(e, "Failed to prepare the handler chain");
+        }
+    }
+
+    private bool _disposed;
+
+    public ValueTask DisposeAsync()
+    {
+        if (!_disposed)
+        {
+            _endPoints.Dispose();
+
+            _disposed = true;
+        }
+
+        return new();
+    }
+}

--- a/Engine/InternalH3Experimental/Infrastructure/H3ServerHost.cs
+++ b/Engine/InternalH3Experimental/Infrastructure/H3ServerHost.cs
@@ -8,7 +8,11 @@ namespace GenHTTP.Engine.InternalH3Experimental.Infrastructure;
 
 internal sealed class H3ServerHost : ServerHost
 {
+    private readonly int _qpackCapacity;
 
-    protected override IServer Build(ServerConfiguration config, IHandler handler) => new H3Server(config, handler);
+    internal H3ServerHost(int qpackCapacity) => _qpackCapacity = qpackCapacity;
+
+    protected override IServer Build(ServerConfiguration config, IHandler handler)
+        => new H3Server(config, handler, _qpackCapacity);
 
 }

--- a/Engine/InternalH3Experimental/Infrastructure/H3ServerHost.cs
+++ b/Engine/InternalH3Experimental/Infrastructure/H3ServerHost.cs
@@ -1,0 +1,14 @@
+using GenHTTP.Api.Content;
+using GenHTTP.Api.Infrastructure;
+
+using GenHTTP.Engine.Shared.Hosting;
+using GenHTTP.Engine.Shared.Infrastructure;
+
+namespace GenHTTP.Engine.InternalH3Experimental.Infrastructure;
+
+internal sealed class H3ServerHost : ServerHost
+{
+
+    protected override IServer Build(ServerConfiguration config, IHandler handler) => new H3Server(config, handler);
+
+}

--- a/Engine/InternalH3Experimental/Infrastructure/QuicEndPoint.cs
+++ b/Engine/InternalH3Experimental/Infrastructure/QuicEndPoint.cs
@@ -1,0 +1,140 @@
+using System.Net;
+using System.Net.Quic;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+using GenHTTP.Api.Infrastructure;
+
+using GenHTTP.Engine.InternalH3Experimental.Protocol;
+using GenHTTP.Engine.Shared.Infrastructure;
+
+using Microsoft.Extensions.Logging;
+
+namespace GenHTTP.Engine.InternalH3Experimental.Infrastructure;
+
+/// <summary>
+/// A QUIC listener serving HTTP/3.
+/// </summary>
+/// <remarks>
+/// Does not derive from the Internal engine's EndPoint, which creates a TCP socket in its base
+/// class and hands each connection over as a Stream. QUIC has neither.
+/// </remarks>
+internal sealed class QuicEndPoint : IEndPoint
+{
+    private readonly IServer _server;
+
+    private readonly ILogger _logger;
+
+    private readonly EndPointConfiguration _configuration;
+
+    private readonly CancellationTokenSource _shutdown = new();
+
+    private QuicListener? _listener;
+
+    private Task? _accepting;
+
+    internal QuicEndPoint(IServer server, EndPointConfiguration configuration)
+    {
+        _server = server;
+        _configuration = configuration;
+        _logger = server.Logging.CreateLogger<QuicEndPoint>();
+
+        Address = configuration.Address;
+        Port = configuration.Port;
+        DualStack = configuration.DualStack;
+    }
+
+    public IPAddress? Address { get; }
+
+    public ushort Port { get; }
+
+    public bool DualStack { get; }
+
+    // QUIC has no cleartext mode: TLS 1.3 is inside the transport.
+    public bool Secure => true;
+
+    internal async ValueTask StartAsync()
+    {
+        if (!QuicListener.IsSupported)
+        {
+            throw new NotSupportedException(
+                "QUIC is not available on this system. libmsquic must be present and TLS 1.3 supported. "
+                + "See https://learn.microsoft.com/dotnet/fundamentals/networking/quic/quic-overview");
+        }
+
+        if (_configuration.Security is null)
+        {
+            throw new InvalidOperationException("An HTTP/3 endpoint requires a certificate; bind it with one.");
+        }
+
+        X509Certificate2 certificate = _configuration.Security.CertificateProvider.Provide(null)
+                                      ?? throw new InvalidOperationException("The certificate provider did not supply a certificate for the HTTP/3 endpoint.");
+
+        IPAddress address = Address ?? (DualStack ? IPAddress.IPv6Any : IPAddress.Any);
+
+        _listener = await QuicListener.ListenAsync(new QuicListenerOptions
+        {
+            ListenEndPoint = new IPEndPoint(address, Port),
+            ApplicationProtocols = [SslApplicationProtocol.Http3],
+            ConnectionOptionsCallback = (_, _, _) => ValueTask.FromResult(new QuicServerConnectionOptions
+            {
+                DefaultStreamErrorCode = 0x010c,   // H3_REQUEST_CANCELLED
+                DefaultCloseErrorCode = 0x0100,    // H3_NO_ERROR
+                ServerAuthenticationOptions = new SslServerAuthenticationOptions
+                {
+                    ApplicationProtocols = [SslApplicationProtocol.Http3],
+                    ServerCertificate = certificate,
+                },
+            }),
+        });
+
+        _logger.LogInformation("Listening on {Address}:{Port} (HTTP/3 over QUIC)", address, Port);
+
+        _accepting = Task.Run(AcceptAsync);
+    }
+
+    private async Task AcceptAsync()
+    {
+        try
+        {
+            while (!_shutdown.IsCancellationRequested)
+            {
+                QuicConnection connection = await _listener!.AcceptConnectionAsync(_shutdown.Token);
+
+                _ = ServeAsync(connection);
+            }
+        }
+        catch (Exception e)
+        {
+            if (!_shutdown.IsCancellationRequested)
+            {
+                _logger.LogError(e, "Failed to accept incoming connection");
+            }
+        }
+    }
+
+    private async Task ServeAsync(QuicConnection connection)
+    {
+        try
+        {
+            await H3Connection.ServeAsync(connection, _server, this, _logger, _shutdown.Token);
+        }
+        catch (Exception e)
+        {
+            _logger.LogDebug(e, "Connection ended");
+        }
+    }
+
+    public void Dispose()
+    {
+        _shutdown.Cancel();
+
+        if (_listener is not null)
+        {
+            _listener.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            _listener = null;
+        }
+
+        _shutdown.Dispose();
+    }
+}

--- a/Engine/InternalH3Experimental/Infrastructure/QuicEndPoint.cs
+++ b/Engine/InternalH3Experimental/Infrastructure/QuicEndPoint.cs
@@ -117,7 +117,8 @@ internal sealed class QuicEndPoint : IEndPoint
     {
         try
         {
-            await H3Connection.ServeAsync(connection, _server, this, _logger, _shutdown.Token);
+            await H3Connection.ServeAsync(connection, _server, this, _logger,
+                (_server as H3Server)?.QpackCapacity ?? 0, _shutdown.Token);
         }
         catch (Exception e)
         {

--- a/Engine/InternalH3Experimental/Infrastructure/QuicEndPointCollection.cs
+++ b/Engine/InternalH3Experimental/Infrastructure/QuicEndPointCollection.cs
@@ -1,0 +1,41 @@
+using System.Collections;
+
+using GenHTTP.Api.Infrastructure;
+
+using GenHTTP.Engine.Shared.Infrastructure;
+
+namespace GenHTTP.Engine.InternalH3Experimental.Infrastructure;
+
+internal sealed class QuicEndPointCollection : IEndPointCollection, IDisposable
+{
+    private readonly List<QuicEndPoint> _endPoints;
+
+    internal QuicEndPointCollection(IServer server, IEnumerable<EndPointConfiguration> configuration)
+    {
+        _endPoints = configuration.Select(c => new QuicEndPoint(server, c)).ToList();
+    }
+
+    internal async ValueTask StartAsync()
+    {
+        foreach (QuicEndPoint endPoint in _endPoints)
+        {
+            await endPoint.StartAsync();
+        }
+    }
+
+    public IEndPoint this[int index] => _endPoints[index];
+
+    public int Count => _endPoints.Count;
+
+    public IEnumerator<IEndPoint> GetEnumerator() => _endPoints.Cast<IEndPoint>().GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public void Dispose()
+    {
+        foreach (QuicEndPoint endPoint in _endPoints)
+        {
+            endPoint.Dispose();
+        }
+    }
+}

--- a/Engine/InternalH3Experimental/Protocol/H3Connection.cs
+++ b/Engine/InternalH3Experimental/Protocol/H3Connection.cs
@@ -261,6 +261,17 @@ internal sealed class H3Connection : IHttp3Transport, IAsyncDisposable
                         {
                             stream.CompleteWrites();
                         }
+
+                        // A finished request stream must be released, or its stream credit is never
+                        // returned and the peer stalls after MaxInboundBidirectionalStreams
+                        // requests. Unidirectional streams are the connection's control and QPACK
+                        // streams and live as long as it does.
+                        if (item.Fin && (item.StreamId & 0x3) == 0x0 && _streams.TryRemove(item.StreamId, out QuicStream? finished))
+                        {
+                            // Off the writer: tearing a stream down is slow enough that awaiting it
+                            // here serialises every other request behind it.
+                            _ = finished.DisposeAsync().AsTask();
+                        }
                     }
                     ArrayPool<byte>.Shared.Return(item.Buffer);
                 }

--- a/Engine/InternalH3Experimental/Protocol/H3Connection.cs
+++ b/Engine/InternalH3Experimental/Protocol/H3Connection.cs
@@ -43,6 +43,8 @@ internal sealed class H3Connection : IHttp3Transport, IAsyncDisposable
 
     private Http3Connection? _h3;
 
+    private const int ServerUniStreams = 1;
+
     // Stream bytes, a stream ending, or a continuation that must run on the pump thread.
     private readonly record struct Inbound(long StreamId, byte[]? Buffer, int Length, bool Fin, bool Closed, Action? Resume);
 
@@ -64,8 +66,14 @@ internal sealed class H3Connection : IHttp3Transport, IAsyncDisposable
 
     private async Task RunAsync(CancellationToken cancellationToken)
     {
-        // Opened before Glyph3 exists, because OpenUniStream answers synchronously.
-        for (int i = 0; i < 3; i++)
+        // Opened before Glyph3 exists, because OpenUniStream answers synchronously while
+        // OpenOutboundStreamAsync does not.
+        //
+        // One is enough: Glyph3 asks for a single unidirectional stream, for control and SETTINGS.
+        // HTTP/3 also defines QPACK encoder and decoder streams, but Glyph3 advertises a dynamic
+        // table capacity of 0, so there is nothing to insert and nothing to acknowledge. Raise this
+        // if that ever changes.
+        for (int i = 0; i < ServerUniStreams; i++)
         {
             QuicStream uni = await _quic.OpenOutboundStreamAsync(QuicStreamType.Unidirectional, cancellationToken);
             _streams[uni.Id] = uni;

--- a/Engine/InternalH3Experimental/Protocol/H3Connection.cs
+++ b/Engine/InternalH3Experimental/Protocol/H3Connection.cs
@@ -1,0 +1,310 @@
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Quic;
+using System.Threading.Channels;
+
+using GenHTTP.Api.Infrastructure;
+using GenHTTP.Api.Protocol;
+
+using Glyph3;
+
+using Microsoft.Extensions.Logging;
+
+namespace GenHTTP.Engine.InternalH3Experimental.Protocol;
+
+/// <summary>
+/// One HTTP/3 connection: MsQuic underneath, Glyph3 on top, GenHTTP's handler chain in the middle.
+/// </summary>
+/// <remarks>
+/// Glyph3 is a single state machine, so every call into it is funnelled through one channel and one
+/// consumer. Handlers run off that thread and their responses are posted back, which is what lets
+/// several requests be in flight on one connection without the parser ever seeing two threads.
+/// </remarks>
+internal sealed class H3Connection : IHttp3Transport, IAsyncDisposable
+{
+    private readonly QuicConnection _quic;
+
+    private readonly IServer _server;
+
+    private readonly IEndPoint _endPoint;
+
+    private readonly ILogger _logger;
+
+    private readonly ConcurrentDictionary<long, QuicStream> _streams = new();
+
+    private readonly Queue<QuicStream> _spareUniStreams = new();
+
+    private readonly Channel<Inbound> _ingress =
+        Channel.CreateUnbounded<Inbound>(new UnboundedChannelOptions { SingleReader = true });
+
+    private readonly Channel<Outbound> _egress =
+        Channel.CreateUnbounded<Outbound>(new UnboundedChannelOptions { SingleReader = true });
+
+    private Http3Connection? _h3;
+
+    // Stream bytes, a stream ending, or a continuation that must run on the pump thread.
+    private readonly record struct Inbound(long StreamId, byte[]? Buffer, int Length, bool Fin, bool Closed, Action? Resume);
+
+    private readonly record struct Outbound(long StreamId, byte[] Buffer, int Length, bool Fin);
+
+    private H3Connection(QuicConnection quic, IServer server, IEndPoint endPoint, ILogger logger)
+    {
+        _quic = quic;
+        _server = server;
+        _endPoint = endPoint;
+        _logger = logger;
+    }
+
+    internal static async Task ServeAsync(QuicConnection quic, IServer server, IEndPoint endPoint, ILogger logger, CancellationToken cancellationToken)
+    {
+        await using var connection = new H3Connection(quic, server, endPoint, logger);
+        await connection.RunAsync(cancellationToken);
+    }
+
+    private async Task RunAsync(CancellationToken cancellationToken)
+    {
+        // Opened before Glyph3 exists, because OpenUniStream answers synchronously.
+        for (int i = 0; i < 3; i++)
+        {
+            QuicStream uni = await _quic.OpenOutboundStreamAsync(QuicStreamType.Unidirectional, cancellationToken);
+            _streams[uni.Id] = uni;
+            _spareUniStreams.Enqueue(uni);
+        }
+
+        _h3 = new Http3Connection(this, DispatchAsync);
+
+        Task accepting = AcceptStreamsAsync(cancellationToken);
+        Task writing = WriteLoopAsync(cancellationToken);
+
+        try
+        {
+            await PumpAsync(cancellationToken);
+        }
+        finally
+        {
+            _h3.Close();
+            _egress.Writer.TryComplete();
+            _ingress.Writer.TryComplete();
+            await Task.WhenAny(Task.WhenAll(accepting, writing), Task.Delay(1000, CancellationToken.None));
+        }
+    }
+
+    // Glyph3 calls this on the pump thread and awaits the result before submitting the response.
+    // Task.Run moves the handler chain off the pump, so its own awaits do not inherit the pump's
+    // context and it never blocks the parser. Glyph3's await, captured here, comes back through
+    // PumpContext, so the submit still happens on the pump thread.
+    private ValueTask<Http3Response> DispatchAsync(Http3Request request)
+        => new(Task.Run(() => HandleAsync(request)));
+
+    private async Task<Http3Response> HandleAsync(Http3Request source)
+    {
+        try
+        {
+            // Glyph3 dispatches at end-of-headers, so the body is still arriving. Assemble it
+            // before the handler runs, which is the shape GenHTTP's IRequestBody expects.
+            ReadOnlyMemory<byte> body = await ReadBodyAsync(source);
+
+            var request = new H3Request(_server, _endPoint, source, body, RemoteAddress());
+
+            IResponse response = await _server.Handler.HandleAsync(request)
+                                 ?? throw new InvalidOperationException("The root request handler did not return a response");
+
+            bool head = request.Header.Method == RequestMethod.Head;
+
+            return await H3ResponseWriter.BuildAsync(response, head);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to handle request");
+            return new Http3Response { Status = 500 };
+        }
+    }
+
+    private async Task PumpAsync(CancellationToken cancellationToken)
+    {
+        var context = new PumpContext(_ingress.Writer);
+
+        Enter(context);
+        _h3!.Start();
+        Leave();
+
+        // ConfigureAwait(false) matters: with the context installed the pump would post its OWN
+        // continuation to the queue only it drains, and wait forever for itself.
+        while (await _ingress.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            Enter(context);
+
+            while (_ingress.Reader.TryRead(out Inbound item))
+            {
+                if (item.Resume is { } resume)
+                {
+                    resume();
+                }
+                else if (item.Closed)
+                {
+                    _h3.OnStreamClosed(item.StreamId);
+                }
+                else
+                {
+                    _h3.Feed(item.StreamId, item.Buffer.AsSpan(0, item.Length), item.Fin);
+
+                    if (item.Buffer is not null)
+                    {
+                        ArrayPool<byte>.Shared.Return(item.Buffer);
+                    }
+                }
+            }
+
+            _h3.Flush();
+
+            Leave();
+
+            if (_h3.IsFaulted)
+            {
+                return;
+            }
+        }
+    }
+
+    // Installed only around calls into Glyph3, so anything it awaits while dispatching resumes on
+    // the pump rather than the thread pool.
+    private static void Enter(SynchronizationContext context) => SynchronizationContext.SetSynchronizationContext(context);
+
+    private static void Leave() => SynchronizationContext.SetSynchronizationContext(null);
+
+    private static async ValueTask<ReadOnlyMemory<byte>> ReadBodyAsync(Http3Request source)
+    {
+        if (source.BodyReader is not { } reader)
+        {
+            return source.Body;
+        }
+
+        ArrayBufferWriter<byte>? assembled = null;
+
+        while (true)
+        {
+            ReadOnlyMemory<byte> chunk = await reader.ReadAsync();
+
+            if (chunk.IsEmpty)
+            {
+                break;
+            }
+
+            assembled ??= new ArrayBufferWriter<byte>(chunk.Length);
+            assembled.Write(chunk.Span);
+        }
+
+        return assembled?.WrittenMemory ?? ReadOnlyMemory<byte>.Empty;
+    }
+
+    private IPAddress? RemoteAddress()
+        => _quic.RemoteEndPoint is IPEndPoint endpoint ? endpoint.Address : null;
+
+    private async Task AcceptStreamsAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                QuicStream stream = await _quic.AcceptInboundStreamAsync(cancellationToken);
+                _streams[stream.Id] = stream;
+                _ = ReadStreamAsync(stream, cancellationToken);
+            }
+        }
+        catch (Exception)
+        {
+            // The connection closed, which is how an accept loop ends.
+        }
+    }
+
+    private async Task ReadStreamAsync(QuicStream stream, CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (true)
+            {
+                byte[] buffer = ArrayPool<byte>.Shared.Rent(16 * 1024);
+                int read = await stream.ReadAsync(buffer, cancellationToken);
+
+                if (read == 0)
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
+                    await _ingress.Writer.WriteAsync(new Inbound(stream.Id, null, 0, true, false, null), cancellationToken);
+                    return;
+                }
+
+                await _ingress.Writer.WriteAsync(new Inbound(stream.Id, buffer, read, false, false, null), cancellationToken);
+            }
+        }
+        catch (Exception)
+        {
+            _ingress.Writer.TryWrite(new Inbound(stream.Id, null, 0, false, true, null));
+        }
+    }
+
+    private async Task WriteLoopAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (await _egress.Reader.WaitToReadAsync(cancellationToken))
+            {
+                while (_egress.Reader.TryRead(out Outbound item))
+                {
+                    if (_streams.TryGetValue(item.StreamId, out QuicStream? stream))
+                    {
+                        if (item.Length > 0)
+                        {
+                            await stream.WriteAsync(item.Buffer.AsMemory(0, item.Length), item.Fin, cancellationToken);
+                        }
+                        else if (item.Fin)
+                        {
+                            stream.CompleteWrites();
+                        }
+                    }
+                    ArrayPool<byte>.Shared.Return(item.Buffer);
+                }
+            }
+        }
+        catch (Exception)
+        {
+            // Peer went away mid-write.
+        }
+    }
+
+    public long OpenUniStream() => _spareUniStreams.TryDequeue(out QuicStream? stream) ? stream.Id : -1;
+
+    public void Send(long streamId, ReadOnlySpan<byte> data, bool fin)
+    {
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(Math.Max(1, data.Length));
+        data.CopyTo(buffer);
+        _egress.Writer.TryWrite(new Outbound(streamId, buffer, data.Length, fin));
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (QuicStream stream in _streams.Values)
+        {
+            await stream.DisposeAsync();
+        }
+        await _quic.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Posts continuations back to the pump, so anything Glyph3 awaits resumes on the one thread
+    /// allowed to touch it.
+    /// </summary>
+    private sealed class PumpContext : SynchronizationContext
+    {
+        private readonly ChannelWriter<Inbound> _pump;
+
+        internal PumpContext(ChannelWriter<Inbound> pump) => _pump = pump;
+
+        public override void Post(SendOrPostCallback d, object? state)
+            => _pump.TryWrite(new Inbound(0, null, 0, false, false, () => d(state)));
+
+        public override void Send(SendOrPostCallback d, object? state) => Post(d, state);
+
+        public override SynchronizationContext CreateCopy() => this;
+    }
+}

--- a/Engine/InternalH3Experimental/Protocol/H3Connection.cs
+++ b/Engine/InternalH3Experimental/Protocol/H3Connection.cs
@@ -18,8 +18,8 @@ namespace GenHTTP.Engine.InternalH3Experimental.Protocol;
 /// </summary>
 /// <remarks>
 /// Glyph3 is a single state machine, so every call into it is funnelled through one channel and one
-/// consumer. Handlers run off that thread and their responses are posted back, which is what lets
-/// several requests be in flight on one connection without the parser ever seeing two threads.
+/// consumer - the pump. Handlers start on that thread and, if they suspend, resume back onto it
+/// through PumpContext, so several requests can be in flight without the parser seeing two threads.
 /// </remarks>
 internal sealed class H3Connection : IHttp3Transport, IAsyncDisposable
 {
@@ -91,9 +91,6 @@ internal sealed class H3Connection : IHttp3Transport, IAsyncDisposable
     }
 
     // Glyph3 calls this on the pump thread and awaits the result before submitting the response.
-    // Task.Run moves the handler chain off the pump, so its own awaits do not inherit the pump's
-    // context and it never blocks the parser. Glyph3's await, captured here, comes back through
-    // PumpContext, so the submit still happens on the pump thread.
     private ValueTask<Http3Response> DispatchAsync(Http3Request request)
     {
         // Start the handler INLINE. A chain that completes synchronously - which the common case

--- a/Engine/InternalH3Experimental/Protocol/H3Connection.cs
+++ b/Engine/InternalH3Experimental/Protocol/H3Connection.cs
@@ -50,37 +50,47 @@ internal sealed class H3Connection : IHttp3Transport, IAsyncDisposable
 
     private readonly record struct Outbound(long StreamId, byte[] Buffer, int Length, bool Fin);
 
-    private H3Connection(QuicConnection quic, IServer server, IEndPoint endPoint, ILogger logger)
+    private readonly int _qpackCapacity;
+
+    private H3Connection(QuicConnection quic, IServer server, IEndPoint endPoint, ILogger logger, int qpackCapacity)
     {
         _quic = quic;
         _server = server;
         _endPoint = endPoint;
         _logger = logger;
+        _qpackCapacity = qpackCapacity;
     }
 
-    internal static async Task ServeAsync(QuicConnection quic, IServer server, IEndPoint endPoint, ILogger logger, CancellationToken cancellationToken)
+    internal static async Task ServeAsync(QuicConnection quic, IServer server, IEndPoint endPoint, ILogger logger,
+        int qpackCapacity, CancellationToken cancellationToken)
     {
-        await using var connection = new H3Connection(quic, server, endPoint, logger);
+        await using var connection = new H3Connection(quic, server, endPoint, logger, qpackCapacity);
         await connection.RunAsync(cancellationToken);
     }
 
     private async Task RunAsync(CancellationToken cancellationToken)
     {
         // Opened before Glyph3 exists, because OpenUniStream answers synchronously while
-        // OpenOutboundStreamAsync does not.
+        // OpenOutboundStreamAsync does not. With the dynamic table on it also wants a QPACK
+        // decoder stream, and an encoder stream if the client advertises a table of its own.
         //
         // One is enough: Glyph3 asks for a single unidirectional stream, for control and SETTINGS.
         // HTTP/3 also defines QPACK encoder and decoder streams, but Glyph3 advertises a dynamic
         // table capacity of 0, so there is nothing to insert and nothing to acknowledge. Raise this
         // if that ever changes.
-        for (int i = 0; i < ServerUniStreams; i++)
+        int uniStreams = _qpackCapacity > 0 ? ServerUniStreams + 2 : ServerUniStreams;
+
+        for (int i = 0; i < uniStreams; i++)
         {
             QuicStream uni = await _quic.OpenOutboundStreamAsync(QuicStreamType.Unidirectional, cancellationToken);
             _streams[uni.Id] = uni;
             _spareUniStreams.Enqueue(uni);
         }
 
-        _h3 = new Http3Connection(this, DispatchAsync);
+        _h3 = new Http3Connection(this, DispatchAsync, new Http3Options
+        {
+            QpackDynamicTableCapacity = _qpackCapacity,
+        });
 
         Task accepting = AcceptStreamsAsync(cancellationToken);
         Task writing = WriteLoopAsync(cancellationToken);

--- a/Engine/InternalH3Experimental/Protocol/H3Connection.cs
+++ b/Engine/InternalH3Experimental/Protocol/H3Connection.cs
@@ -95,7 +95,15 @@ internal sealed class H3Connection : IHttp3Transport, IAsyncDisposable
     // context and it never blocks the parser. Glyph3's await, captured here, comes back through
     // PumpContext, so the submit still happens on the pump thread.
     private ValueTask<Http3Response> DispatchAsync(Http3Request request)
-        => new(Task.Run(() => HandleAsync(request)));
+    {
+        // Start the handler INLINE. A chain that completes synchronously - which the common case
+        // does - then costs no thread hop at all, and Glyph3 submits the response without ever
+        // leaving the pump. Only a handler that actually suspends pays for a continuation, and it
+        // comes back through PumpContext.
+        Task<Http3Response> pending = HandleAsync(request);
+
+        return new ValueTask<Http3Response>(pending);
+    }
 
     private async Task<Http3Response> HandleAsync(Http3Request source)
     {

--- a/Engine/InternalH3Experimental/Protocol/H3Connection.cs
+++ b/Engine/InternalH3Experimental/Protocol/H3Connection.cs
@@ -136,7 +136,9 @@ internal sealed class H3Connection : IHttp3Transport, IAsyncDisposable
     // Glyph3 calls this on the pump thread and awaits the result before submitting the response.
     private ValueTask<Http3Response> DispatchAsync(Http3Request request)
     {
-        // Start the handler INLINE. A chain that completes synchronously - which the common case
+        // Start the handler INLINE. Measured against the alternative: dispatching it to the pool
+        // with Task.Run collapsed throughput to 75k req/s from 291k, because the pump then waits on
+        // a pool that the offloaded work is itself competing for. A chain that completes synchronously - which the common case
         // does - then costs no thread hop at all, and Glyph3 submits the response without ever
         // leaving the pump. Only a handler that actually suspends pays for a continuation, and it
         // comes back through PumpContext.
@@ -291,38 +293,65 @@ internal sealed class H3Connection : IHttp3Transport, IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Issues every write it can, then awaits them together.
+    /// </summary>
+    /// <remarks>
+    /// Awaiting each write before starting the next leaves MsQuic with one stream's data pending at
+    /// a time, so it cannot fill a datagram from several streams at once - the coalescing that makes
+    /// UDP segmentation offload worth anything. Issuing first and draining after lets it see the
+    /// whole batch. Ordering within a stream still holds: a second write to a stream already in
+    /// flight drains first.
+    /// </remarks>
     private async Task WriteLoopAsync(CancellationToken cancellationToken)
     {
+        var inflight = new List<Pending>();
+        var busy = new HashSet<long>();
+
         try
         {
             while (await _egress.Reader.WaitToReadAsync(cancellationToken))
             {
                 while (_egress.Reader.TryRead(out Outbound item))
                 {
-                    if (_streams.TryGetValue(item.StreamId, out QuicStream? stream))
+                    if (!_streams.TryGetValue(item.StreamId, out QuicStream? stream))
                     {
-                        if (item.Length > 0)
-                        {
-                            await stream.WriteAsync(item.Buffer.AsMemory(0, item.Length), item.Fin, cancellationToken);
-                        }
-                        else if (item.Fin)
+                        ArrayPool<byte>.Shared.Return(item.Buffer);
+                        continue;
+                    }
+
+                    if (item.Length == 0)
+                    {
+                        if (item.Fin)
                         {
                             stream.CompleteWrites();
                         }
 
-                        // A finished request stream must be released, or its stream credit is never
-                        // returned and the peer stalls after MaxInboundBidirectionalStreams
-                        // requests. Unidirectional streams are the connection's control and QPACK
-                        // streams and live as long as it does.
-                        if (item.Fin && (item.StreamId & 0x3) == 0x0 && _streams.TryRemove(item.StreamId, out QuicStream? finished))
-                        {
-                            // Off the writer: tearing a stream down is slow enough that awaiting it
-                            // here serialises every other request behind it.
-                            _ = finished.DisposeAsync().AsTask();
-                        }
+                        ArrayPool<byte>.Shared.Return(item.Buffer);
+                        Release(item.StreamId, item.Fin);
+                        continue;
                     }
-                    ArrayPool<byte>.Shared.Return(item.Buffer);
+
+                    if (!busy.Add(item.StreamId))
+                    {
+                        await DrainAsync(inflight, busy);
+                        busy.Add(item.StreamId);
+                    }
+
+                    ValueTask write = stream.WriteAsync(item.Buffer.AsMemory(0, item.Length), item.Fin, cancellationToken);
+
+                    if (write.IsCompletedSuccessfully)
+                    {
+                        ArrayPool<byte>.Shared.Return(item.Buffer);
+                        Release(item.StreamId, item.Fin);
+                    }
+                    else
+                    {
+                        inflight.Add(new Pending(write, item.Buffer, item.StreamId, item.Fin));
+                    }
                 }
+
+                await DrainAsync(inflight, busy);
             }
         }
         catch (Exception)
@@ -330,6 +359,45 @@ internal sealed class H3Connection : IHttp3Transport, IAsyncDisposable
             // Peer went away mid-write.
         }
     }
+
+    private async ValueTask DrainAsync(List<Pending> inflight, HashSet<long> busy)
+    {
+        foreach (Pending pending in inflight)
+        {
+            try
+            {
+                await pending.Write;
+            }
+            catch (Exception)
+            {
+                // Peer went away mid-write; the connection is finished either way.
+            }
+
+            ArrayPool<byte>.Shared.Return(pending.Buffer);
+            Release(pending.StreamId, pending.Fin);
+        }
+
+        inflight.Clear();
+        busy.Clear();
+    }
+
+    /// <summary>
+    /// Releases a finished request stream. Skipping this strands its credit and the peer stalls
+    /// after MaxInboundBidirectionalStreams requests.
+    /// </summary>
+    private void Release(long streamId, bool fin)
+    {
+        // Unidirectional streams are the connection's control and QPACK streams; they live as long
+        // as it does.
+        if (fin && (streamId & 0x3) == 0x0 && _streams.TryRemove(streamId, out QuicStream? finished))
+        {
+            // Off the writer: tearing a stream down is slow enough that awaiting it here serialises
+            // every other request behind it.
+            _ = finished.DisposeAsync().AsTask();
+        }
+    }
+
+    private readonly record struct Pending(ValueTask Write, byte[] Buffer, long StreamId, bool Fin);
 
     public long OpenUniStream() => _spareUniStreams.TryDequeue(out QuicStream? stream) ? stream.Id : -1;
 

--- a/Engine/InternalH3Experimental/Protocol/H3Connection.cs
+++ b/Engine/InternalH3Experimental/Protocol/H3Connection.cs
@@ -71,13 +71,13 @@ internal sealed class H3Connection : IHttp3Transport, IAsyncDisposable
     private async Task RunAsync(CancellationToken cancellationToken)
     {
         // Opened before Glyph3 exists, because OpenUniStream answers synchronously while
-        // OpenOutboundStreamAsync does not. With the dynamic table on it also wants a QPACK
-        // decoder stream, and an encoder stream if the client advertises a table of its own.
+        // OpenOutboundStreamAsync does not.
         //
-        // One is enough: Glyph3 asks for a single unidirectional stream, for control and SETTINGS.
-        // HTTP/3 also defines QPACK encoder and decoder streams, but Glyph3 advertises a dynamic
-        // table capacity of 0, so there is nothing to insert and nothing to acknowledge. Raise this
-        // if that ever changes.
+        // One is enough at capacity 0: Glyph3 asks for a single unidirectional stream, for control
+        // and SETTINGS, and with no dynamic table there is nothing to insert and nothing to
+        // acknowledge. With a capacity it also wants the QPACK decoder stream, plus an encoder
+        // stream for the case where the client advertises a table of its own. The encoder one goes
+        // unused if the client then advertises 0, which every non-browser client does.
         int uniStreams = _qpackCapacity > 0 ? ServerUniStreams + 2 : ServerUniStreams;
 
         for (int i = 0; i < uniStreams; i++)
@@ -101,11 +101,36 @@ internal sealed class H3Connection : IHttp3Transport, IAsyncDisposable
         }
         finally
         {
+            ReportQpack();
+
             _h3.Close();
             _egress.Writer.TryComplete();
             _ingress.Writer.TryComplete();
             await Task.WhenAny(Task.WhenAll(accepting, writing), Task.Delay(1000, CancellationToken.None));
         }
+    }
+
+    /// <summary>
+    /// Reports what QPACK actually did on this connection, which is otherwise invisible.
+    /// </summary>
+    /// <remarks>
+    /// A capacity of 0 is worth distinguishing from SETTINGS that never arrived, since both leave
+    /// the counters at 0 while meaning entirely different things. In practice only browsers
+    /// advertise a table at all: everything else sends 0, which makes the dynamic table inert no
+    /// matter what capacity this engine was configured with.
+    /// </remarks>
+    private void ReportQpack()
+    {
+        if (_h3 is null || !_logger.IsEnabled(LogLevel.Debug))
+        {
+            return;
+        }
+
+        _logger.LogDebug(
+            "HTTP/3 connection closed: peer QPACK table {Capacity}, dynamic inserts in {Inbound} / out {Outbound}",
+            _h3.PeerSettingsReceived ? $"{_h3.PeerDynamicTableCapacity} B" : "never advertised",
+            _h3.InboundDynamicInserts,
+            _h3.OutboundDynamicInserts);
     }
 
     // Glyph3 calls this on the pump thread and awaits the result before submitting the response.

--- a/Engine/InternalH3Experimental/Protocol/H3KeyValueList.cs
+++ b/Engine/InternalH3Experimental/Protocol/H3KeyValueList.cs
@@ -1,0 +1,28 @@
+using GenHTTP.Api.Protocol;
+
+namespace GenHTTP.Engine.InternalH3Experimental.Protocol;
+
+/// <summary>
+/// Header and query lists over Glyph3's decoded fields.
+/// </summary>
+/// <remarks>
+/// The engine carries its own rather than reusing the shared one, which wraps Glyph11's list and
+/// therefore assumes an HTTP/1.1 parse.
+/// </remarks>
+internal sealed class H3KeyValueList : IRequestHeaders, IRequestQuery
+{
+    private readonly List<(ReadOnlyMemory<byte> Name, ReadOnlyMemory<byte> Value)> _entries;
+
+    internal H3KeyValueList(List<(ReadOnlyMemory<byte> Name, ReadOnlyMemory<byte> Value)> entries)
+    {
+        _entries = entries;
+    }
+
+    public int Count => _entries.Count;
+
+    public KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> GetMemoryEntry(int index)
+    {
+        (ReadOnlyMemory<byte> name, ReadOnlyMemory<byte> value) = _entries[index];
+        return new KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(name, value);
+    }
+}

--- a/Engine/InternalH3Experimental/Protocol/H3Request.cs
+++ b/Engine/InternalH3Experimental/Protocol/H3Request.cs
@@ -1,0 +1,123 @@
+using System.IO.Pipelines;
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+
+using GenHTTP.Api.Infrastructure;
+using GenHTTP.Api.Protocol;
+using GenHTTP.Engine.Shared.Types;
+
+using Glyph3;
+
+namespace GenHTTP.Engine.InternalH3Experimental.Protocol;
+
+/// <summary>
+/// An <see cref="IRequest"/> over a Glyph3 request.
+/// </summary>
+/// <remarks>
+/// Not the shared <see cref="Request"/>, whose Source is a Glyph11 BinaryRequest and so assumes an
+/// HTTP/1.1 parse. Nothing here is pooled: HTTP/3 multiplexes, so several of these are live on one
+/// connection at once and a per-connection pool would need locking to be safe.
+/// </remarks>
+internal sealed class H3Request : IRequest
+{
+    private readonly H3RequestBody? _body;
+
+    private readonly ClientConnection _client = new();
+
+    private readonly PropertyBag _properties = new();
+
+    private readonly ResponseBuilder _response = new();
+
+    private Func<IRequestBody, IRequestBody>? _bodyWrapper;
+
+    private IRequestBody? _wrappedBody;
+
+    private bool _bodyFetched;
+
+    internal H3Request(IServer server, IEndPoint endPoint, Http3Request source, ReadOnlyMemory<byte> body, IPAddress? remoteAddress)
+    {
+        Server = server;
+        EndPoint = endPoint;
+
+        Header = new H3RequestHeader(source, ParseQuery(source.Path));
+
+        _body = body.IsEmpty ? null : new H3RequestBody(body);
+
+        _client.Apply(remoteAddress, ClientProtocol.Https, null);
+    }
+
+    public IServer Server { get; }
+
+    public IEndPoint EndPoint { get; }
+
+    public IClientConnection Client => _client;
+
+    public IPropertyBag Properties => _properties;
+
+    public IRequestHeader Header { get; }
+
+    public IRequestBody? GetBody(HeaderAccess headerAccess = HeaderAccess.Retain)
+    {
+        if (_bodyFetched)
+        {
+            throw new InvalidOperationException("Request body can only be fetched once.");
+        }
+
+        _bodyFetched = true;
+
+        if (_body is null)
+        {
+            return null;
+        }
+
+        return _wrappedBody = _bodyWrapper is not null ? _bodyWrapper(_body) : _body;
+    }
+
+    public void WrapBody(Func<IRequestBody, IRequestBody> wrapper) => _bodyWrapper = wrapper;
+
+    public IResponseBuilder Respond() => _response.Status(ResponseStatus.Ok);
+
+    /// <summary>
+    /// Not supported. Upgrading a request to a raw byte stream is an HTTP/1.1 mechanism, and QUIC
+    /// streams are reached through the transport rather than through the request.
+    /// </summary>
+    public PipeReader Upgrade()
+        => throw new NotSupportedException("Connection upgrades are not available over HTTP/3.");
+
+    public ValueTask DisposeAsync() => new();
+
+    // The query string, which HTTP/3 carries inside :path exactly as HTTP/1.1 carries it inside the
+    // request target.
+    private static List<(ReadOnlyMemory<byte> Name, ReadOnlyMemory<byte> Value)> ParseQuery(ReadOnlyMemory<byte> path)
+    {
+        var parameters = new List<(ReadOnlyMemory<byte>, ReadOnlyMemory<byte>)>();
+
+        int mark = path.Span.IndexOf((byte)'?');
+        if (mark < 0)
+        {
+            return parameters;
+        }
+
+        ReadOnlyMemory<byte> query = path[(mark + 1)..];
+
+        while (!query.IsEmpty)
+        {
+            int end = query.Span.IndexOf((byte)'&');
+            ReadOnlyMemory<byte> pair = end < 0 ? query : query[..end];
+            query = end < 0 ? default : query[(end + 1)..];
+
+            if (pair.IsEmpty)
+            {
+                continue;
+            }
+
+            int equals = pair.Span.IndexOf((byte)'=');
+
+            parameters.Add(equals < 0
+                ? (pair, ReadOnlyMemory<byte>.Empty)
+                : (pair[..equals], pair[(equals + 1)..]));
+        }
+
+        return parameters;
+    }
+}

--- a/Engine/InternalH3Experimental/Protocol/H3RequestBody.cs
+++ b/Engine/InternalH3Experimental/Protocol/H3RequestBody.cs
@@ -1,0 +1,25 @@
+using GenHTTP.Api.Protocol;
+
+namespace GenHTTP.Engine.InternalH3Experimental.Protocol;
+
+/// <summary>
+/// A request body that Glyph3 has already assembled.
+/// </summary>
+/// <remarks>
+/// Buffered because this engine uses Glyph3's buffered dispatch: the handler runs once the whole
+/// request has arrived. Glyph3 also has a streamed flavour, which would replace this with a reader
+/// the handler pulls while the body is still in flight.
+/// </remarks>
+internal sealed class H3RequestBody : IRequestBody
+{
+    private readonly ReadOnlyMemory<byte> _content;
+
+    internal H3RequestBody(ReadOnlyMemory<byte> content)
+    {
+        _content = content;
+    }
+
+    public Stream AsStream() => new MemoryStream(_content.ToArray(), writable: false);
+
+    public ValueTask<ReadOnlyMemory<byte>> AsMemoryAsync() => new(_content);
+}

--- a/Engine/InternalH3Experimental/Protocol/H3RequestHeader.cs
+++ b/Engine/InternalH3Experimental/Protocol/H3RequestHeader.cs
@@ -1,0 +1,107 @@
+using GenHTTP.Api.Protocol;
+using GenHTTP.Engine.Shared.Types;
+
+using Glyph3;
+
+namespace GenHTTP.Engine.InternalH3Experimental.Protocol;
+
+/// <summary>
+/// An <see cref="IRequestHeader"/> over a Glyph3 request.
+/// </summary>
+internal sealed class H3RequestHeader : IRequestHeader
+{
+    private readonly H3KeyValueList _headers;
+
+    private readonly H3KeyValueList _query;
+
+    private readonly RequestTarget _target;
+
+    internal H3RequestHeader(Http3Request source, List<(ReadOnlyMemory<byte> Name, ReadOnlyMemory<byte> Value)> query)
+    {
+        _headers = new H3KeyValueList(WithHost(source));
+        _query = new H3KeyValueList(query);
+
+        _target = new RequestTarget();
+
+        // :path carries the query string, exactly as an HTTP/1.1 request target does. Routing must
+        // see the path alone, or every request with a query 404s.
+        Path = new ByteString(WithoutQuery(source.Path));
+        Method = new RequestMethod(source.Method);
+
+        _target.Apply(Path);
+    }
+
+    public RequestMethod Method { get; }
+
+    public ByteString Path { get; }
+
+    public IRequestTarget Target => _target;
+
+    // Always HTTP/3: there is no version on the wire to read. QUIC settles it, and ALPN said "h3"
+    // before a single byte of this request arrived.
+    public HttpProtocol Protocol => HttpProtocol.Http3;
+
+    public ReadOnlyMemory<byte> Version => Http3Version;
+
+    public IRequestHeaders Headers => _headers;
+
+    public IRequestQuery Query => _query;
+
+    /// <summary>
+    /// HTTP/3 carries the authority as the :authority pseudo-header and clients omit Host entirely.
+    /// RFC 9114 4.3.1 has an intermediary translating to HTTP/1.1 construct Host from it, which is
+    /// what this does: everything above the engine expects a Host header to exist.
+    /// </summary>
+    private static List<(ReadOnlyMemory<byte> Name, ReadOnlyMemory<byte> Value)> WithHost(Http3Request source)
+    {
+        if (source.Authority.IsEmpty)
+        {
+            return source.Headers;
+        }
+
+        foreach ((ReadOnlyMemory<byte> name, ReadOnlyMemory<byte> _) in source.Headers)
+        {
+            if (name.Length == 4 && Matches(name.Span, "host"u8))
+            {
+                return source.Headers;
+            }
+        }
+
+        var headers = new List<(ReadOnlyMemory<byte>, ReadOnlyMemory<byte>)>(source.Headers.Count + 1)
+        {
+            (HostName, source.Authority),
+        };
+
+        headers.AddRange(source.Headers);
+
+        return headers;
+    }
+
+    private static bool Matches(ReadOnlySpan<byte> name, ReadOnlySpan<byte> lowercase)
+    {
+        for (int i = 0; i < name.Length; i++)
+        {
+            byte c = name[i];
+            if (c is >= (byte)'A' and <= (byte)'Z')
+            {
+                c += 32;
+            }
+            if (c != lowercase[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static ReadOnlyMemory<byte> WithoutQuery(ReadOnlyMemory<byte> path)
+    {
+        int mark = path.Span.IndexOf((byte)'?');
+        return mark < 0 ? path : path[..mark];
+    }
+
+    private static readonly ReadOnlyMemory<byte> HostName = "host"u8.ToArray();
+
+    private static readonly ReadOnlyMemory<byte> Http3Version = "HTTP/3.0"u8.ToArray();
+}

--- a/Engine/InternalH3Experimental/Protocol/H3ResponseWriter.cs
+++ b/Engine/InternalH3Experimental/Protocol/H3ResponseWriter.cs
@@ -1,0 +1,124 @@
+using System.Buffers;
+
+using GenHTTP.Api.Protocol;
+
+using Glyph3;
+
+namespace GenHTTP.Engine.InternalH3Experimental.Protocol;
+
+/// <summary>
+/// Turns a GenHTTP <see cref="IResponse"/> into a Glyph3 response.
+/// </summary>
+internal static class H3ResponseWriter
+{
+
+    internal static async ValueTask<Http3Response> BuildAsync(IResponse response, bool headRequest)
+    {
+        var headers = new List<(ReadOnlyMemory<byte> Name, ReadOnlyMemory<byte> Value)>();
+
+        for (int i = 0; i < response.Headers.Count; i++)
+        {
+            KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> header = response.Headers.GetMemoryEntry(i);
+
+            // Connection-specific fields are malformed in HTTP/3 (RFC 9114 4.2), and a peer may
+            // treat them as a protocol error rather than ignore them.
+            if (!IsConnectionSpecific(header.Key.Span))
+            {
+                headers.Add((Lowercase(header.Key), header.Value));
+            }
+        }
+
+        ReadOnlyMemory<byte> body = default;
+
+        if (response.Content is { } content)
+        {
+            if (content.Type is { } type)
+            {
+                headers.Add((ContentTypeName, type.Bytes));
+            }
+
+            if (content.Encoding is { } encoding)
+            {
+                headers.Add((ContentEncodingName, encoding));
+            }
+
+            // A HEAD response keeps the headers its GET would have produced and sends no body.
+            if (!headRequest)
+            {
+                var buffer = new ArrayBufferWriter<byte>(
+                    content.Length is { } length and > 0 and < int.MaxValue ? (int)length : 4096);
+
+                await content.WriteAsync(new H3Sink(buffer));
+
+                body = buffer.WrittenMemory;
+            }
+        }
+
+        var result = new Http3Response
+        {
+            Status = (int)response.Status,
+            Body = body,
+        };
+
+        foreach ((ReadOnlyMemory<byte> name, ReadOnlyMemory<byte> value) in headers)
+        {
+            result.Headers.Add((name, value));
+        }
+
+        return result;
+    }
+
+    // HTTP/3 requires lowercase field names; anything else is a malformed message.
+    private static ReadOnlyMemory<byte> Lowercase(ReadOnlyMemory<byte> name)
+    {
+        ReadOnlySpan<byte> span = name.Span;
+
+        for (int i = 0; i < span.Length; i++)
+        {
+            if (span[i] is >= (byte)'A' and <= (byte)'Z')
+            {
+                byte[] lowered = name.ToArray();
+                for (int j = 0; j < lowered.Length; j++)
+                {
+                    if (lowered[j] is >= (byte)'A' and <= (byte)'Z')
+                    {
+                        lowered[j] += 32;
+                    }
+                }
+                return lowered;
+            }
+        }
+
+        return name;
+    }
+
+    private static bool IsConnectionSpecific(ReadOnlySpan<byte> name)
+        => Matches(name, "connection"u8) || Matches(name, "keep-alive"u8) || Matches(name, "transfer-encoding"u8)
+        || Matches(name, "upgrade"u8) || Matches(name, "proxy-connection"u8) || Matches(name, "content-length"u8);
+
+    private static bool Matches(ReadOnlySpan<byte> name, ReadOnlySpan<byte> lowercase)
+    {
+        if (name.Length != lowercase.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < name.Length; i++)
+        {
+            byte c = name[i];
+            if (c is >= (byte)'A' and <= (byte)'Z')
+            {
+                c += 32;
+            }
+            if (c != lowercase[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static readonly ReadOnlyMemory<byte> ContentTypeName = "content-type"u8.ToArray();
+    private static readonly ReadOnlyMemory<byte> ContentEncodingName = "content-encoding"u8.ToArray();
+}

--- a/Engine/InternalH3Experimental/Protocol/H3ResponseWriter.cs
+++ b/Engine/InternalH3Experimental/Protocol/H3ResponseWriter.cs
@@ -41,11 +41,15 @@ internal static class H3ResponseWriter
         {
             KeyValuePair<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> header = response.Headers.GetMemoryEntry(i);
 
+            // Names pass through as they are. HTTP/3 requires them lowercase, but Glyph3 resolves
+            // static-table names case-insensitively - and lowercases the ones it has to write out -
+            // so converting here only duplicated the work and allocated to do it.
+            //
             // Connection-specific fields are malformed in HTTP/3 (RFC 9114 4.2), and a peer may
             // treat them as a protocol error rather than ignore them.
             if (!IsConnectionSpecific(header.Key.Span))
             {
-                result.Headers.Add((Lowercase(header.Key), header.Value));
+                result.Headers.Add((header.Key, header.Value));
             }
         }
 
@@ -63,51 +67,6 @@ internal static class H3ResponseWriter
         }
 
         return result;
-    }
-
-    // The field names GenHTTP actually emits, pre-lowercased. Every one of these arrives with
-    // capitals, so without this table each of them allocated a fresh array on every response.
-    private static readonly byte[][] KnownNames =
-    [
-        "server"u8.ToArray(), "date"u8.ToArray(), "content-type"u8.ToArray(),
-        "content-encoding"u8.ToArray(), "content-disposition"u8.ToArray(), "content-range"u8.ToArray(),
-        "cache-control"u8.ToArray(), "last-modified"u8.ToArray(), "expires"u8.ToArray(),
-        "location"u8.ToArray(), "etag"u8.ToArray(), "vary"u8.ToArray(),
-        "accept-ranges"u8.ToArray(), "set-cookie"u8.ToArray(), "alt-svc"u8.ToArray(),
-        "access-control-allow-origin"u8.ToArray(), "www-authenticate"u8.ToArray(),
-    ];
-
-    // HTTP/3 requires lowercase field names; anything else is a malformed message.
-    private static ReadOnlyMemory<byte> Lowercase(ReadOnlyMemory<byte> name)
-    {
-        ReadOnlySpan<byte> span = name.Span;
-
-        for (int i = 0; i < span.Length; i++)
-        {
-            if (span[i] is >= (byte)'A' and <= (byte)'Z')
-            {
-                // Matches compares case-insensitively, so a known name resolves to a shared array.
-                foreach (byte[] known in KnownNames)
-                {
-                    if (Matches(span, known))
-                    {
-                        return known;
-                    }
-                }
-
-                byte[] lowered = name.ToArray();
-                for (int j = 0; j < lowered.Length; j++)
-                {
-                    if (lowered[j] is >= (byte)'A' and <= (byte)'Z')
-                    {
-                        lowered[j] += 32;
-                    }
-                }
-                return lowered;
-            }
-        }
-
-        return name;
     }
 
     private static bool IsConnectionSpecific(ReadOnlySpan<byte> name)

--- a/Engine/InternalH3Experimental/Protocol/H3ResponseWriter.cs
+++ b/Engine/InternalH3Experimental/Protocol/H3ResponseWriter.cs
@@ -14,7 +14,28 @@ internal static class H3ResponseWriter
 
     internal static async ValueTask<Http3Response> BuildAsync(IResponse response, bool headRequest)
     {
-        var headers = new List<(ReadOnlyMemory<byte> Name, ReadOnlyMemory<byte> Value)>();
+        ReadOnlyMemory<byte> body = default;
+
+        IResponseContent? content = response.Content;
+
+        // A HEAD response keeps the headers its GET would have produced and sends no body.
+        if (content is not null && !headRequest)
+        {
+            var buffer = new ArrayBufferWriter<byte>(
+                content.Length is { } length and > 0 and < int.MaxValue ? (int)length : 4096);
+
+            await content.WriteAsync(new H3Sink(buffer));
+
+            body = buffer.WrittenMemory;
+        }
+
+        // Written straight into the response. Collecting into a list first and copying it across
+        // allocated a second list and its backing array on every single response.
+        var result = new Http3Response
+        {
+            Status = (int)response.Status,
+            Body = body,
+        };
 
         for (int i = 0; i < response.Headers.Count; i++)
         {
@@ -24,49 +45,37 @@ internal static class H3ResponseWriter
             // treat them as a protocol error rather than ignore them.
             if (!IsConnectionSpecific(header.Key.Span))
             {
-                headers.Add((Lowercase(header.Key), header.Value));
+                result.Headers.Add((Lowercase(header.Key), header.Value));
             }
         }
 
-        ReadOnlyMemory<byte> body = default;
-
-        if (response.Content is { } content)
+        if (content is not null)
         {
             if (content.Type is { } type)
             {
-                headers.Add((ContentTypeName, type.Bytes));
+                result.Headers.Add((ContentTypeName, type.Bytes));
             }
 
             if (content.Encoding is { } encoding)
             {
-                headers.Add((ContentEncodingName, encoding));
+                result.Headers.Add((ContentEncodingName, encoding));
             }
-
-            // A HEAD response keeps the headers its GET would have produced and sends no body.
-            if (!headRequest)
-            {
-                var buffer = new ArrayBufferWriter<byte>(
-                    content.Length is { } length and > 0 and < int.MaxValue ? (int)length : 4096);
-
-                await content.WriteAsync(new H3Sink(buffer));
-
-                body = buffer.WrittenMemory;
-            }
-        }
-
-        var result = new Http3Response
-        {
-            Status = (int)response.Status,
-            Body = body,
-        };
-
-        foreach ((ReadOnlyMemory<byte> name, ReadOnlyMemory<byte> value) in headers)
-        {
-            result.Headers.Add((name, value));
         }
 
         return result;
     }
+
+    // The field names GenHTTP actually emits, pre-lowercased. Every one of these arrives with
+    // capitals, so without this table each of them allocated a fresh array on every response.
+    private static readonly byte[][] KnownNames =
+    [
+        "server"u8.ToArray(), "date"u8.ToArray(), "content-type"u8.ToArray(),
+        "content-encoding"u8.ToArray(), "content-disposition"u8.ToArray(), "content-range"u8.ToArray(),
+        "cache-control"u8.ToArray(), "last-modified"u8.ToArray(), "expires"u8.ToArray(),
+        "location"u8.ToArray(), "etag"u8.ToArray(), "vary"u8.ToArray(),
+        "accept-ranges"u8.ToArray(), "set-cookie"u8.ToArray(), "alt-svc"u8.ToArray(),
+        "access-control-allow-origin"u8.ToArray(), "www-authenticate"u8.ToArray(),
+    ];
 
     // HTTP/3 requires lowercase field names; anything else is a malformed message.
     private static ReadOnlyMemory<byte> Lowercase(ReadOnlyMemory<byte> name)
@@ -77,6 +86,15 @@ internal static class H3ResponseWriter
         {
             if (span[i] is >= (byte)'A' and <= (byte)'Z')
             {
+                // Matches compares case-insensitively, so a known name resolves to a shared array.
+                foreach (byte[] known in KnownNames)
+                {
+                    if (Matches(span, known))
+                    {
+                        return known;
+                    }
+                }
+
                 byte[] lowered = name.ToArray();
                 for (int j = 0; j < lowered.Length; j++)
                 {

--- a/Engine/InternalH3Experimental/Protocol/H3Sink.cs
+++ b/Engine/InternalH3Experimental/Protocol/H3Sink.cs
@@ -1,0 +1,67 @@
+using System.Buffers;
+
+using GenHTTP.Api.Protocol;
+
+namespace GenHTTP.Engine.InternalH3Experimental.Protocol;
+
+/// <summary>
+/// The sink a response body writes into.
+/// </summary>
+internal sealed class H3Sink : IResponseSink
+{
+    private readonly ArrayBufferWriter<byte> _writer;
+
+    internal H3Sink(ArrayBufferWriter<byte> writer)
+    {
+        _writer = writer;
+    }
+
+    public IBufferWriter<byte> Writer => _writer;
+
+    public Stream Stream => _stream ??= new BufferWriterStream(_writer);
+
+    private Stream? _stream;
+
+    // Content that writes to a Stream rather than an IBufferWriter, which most of the IO module
+    // does.
+    private sealed class BufferWriterStream : Stream
+    {
+        private readonly IBufferWriter<byte> _target;
+
+        internal BufferWriterStream(IBufferWriter<byte> target) => _target = target;
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count) => Write(buffer.AsSpan(offset, count));
+
+        public override void Write(ReadOnlySpan<byte> buffer) => _target.Write(buffer);
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            _target.Write(buffer.Span);
+            return new ValueTask();
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            _target.Write(buffer.AsSpan(offset, count));
+            return Task.CompletedTask;
+        }
+
+        public override void Flush() { }
+        public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+    }
+}

--- a/Engine/InternalH3Experimental/README.md
+++ b/Engine/InternalH3Experimental/README.md
@@ -1,0 +1,42 @@
+# GenHTTP HTTP/3 Engine (experimental)
+
+Serves an application over HTTP/3, using [Glyph3](https://github.com/dotnet-web-stack/Glyph3) for
+HTTP/3 and `System.Net.Quic` (MsQuic) for QUIC.
+
+```csharp
+var h3 = GenHTTP.Engine.InternalH3Experimental.Host.Create()
+                .Handler(app)
+                .Bind(IPAddress.Any, 443, certificate);
+```
+
+Browsers never start on HTTP/3. They connect over TCP first and only try QUIC once a response tells
+them where to find it, so this engine is meant to run beside one that serves HTTP/1.1:
+
+```csharp
+var h1 = GenHTTP.Engine.Internal.Host.Create()
+                .Handler(app)
+                .Add(AltSvc.To(443))     // Alt-Svc: h3=":443"; ma=86400
+                .Bind(IPAddress.Any, 443, certificate);
+```
+
+TCP:443 and UDP:443 are different sockets, so both bind at once. Two things stop the upgrade
+working, both silently: `Alt-Svc` is only honoured when it arrives over TLS, and the certificate on
+the HTTP/3 port must be valid for the origin's host name.
+
+## Requirements
+
+QUIC needs libmsquic present. Windows 11 / Server 2022+ ships it with the .NET runtime; Linux
+installs it (`sudo apt install libmsquic`); macOS uses Homebrew plus `DYLD_FALLBACK_LIBRARY_PATH`.
+The engine throws at startup when it is missing rather than failing later.
+
+## Status
+
+Experimental. Known gaps:
+
+- Request bodies are assembled before the handler runs, so a large upload is held in memory.
+  Glyph3 can stream them; the engine does not yet.
+- Response bodies are buffered for the same reason.
+- `IRequest.Upgrade()` throws: connection upgrades are an HTTP/1.1 mechanism.
+- No server push, no trailers, no 0-RTT.
+- Requests carry their own `IRequest` implementation rather than the shared `Request`, whose
+  `Source` is a Glyph11 `BinaryRequest` and therefore assumes an HTTP/1.1 parse.

--- a/GenHTTP.slnx
+++ b/GenHTTP.slnx
@@ -13,6 +13,7 @@
     </Folder>
     <Folder Name="/Engine/">
         <Project Path="Engine\Internal\GenHTTP.Engine.Internal.csproj" />
+        <Project Path="Engine\InternalH3Experimental\GenHTTP.Engine.InternalH3Experimental.csproj" />
         <Project Path="Engine\Ioxide\GenHTTP.Engine.Ioxide.csproj" />
         <Project Path="Engine\Kestrel\GenHTTP.Engine.Kestrel.csproj" />
         <Project Path="Engine\Shared\GenHTTP.Engine.Shared.csproj" />

--- a/Playground/GenHTTP.Playground.csproj
+++ b/Playground/GenHTTP.Playground.csproj
@@ -18,6 +18,7 @@
         <ProjectReference Include="..\API\GenHTTP.Api.csproj"/>
 
         <ProjectReference Include="..\Engine\Internal\GenHTTP.Engine.Internal.csproj"/>
+        <ProjectReference Include="..\Engine\InternalH3Experimental\GenHTTP.Engine.InternalH3Experimental.csproj"/>
         <ProjectReference Include="..\Engine\Kestrel\GenHTTP.Engine.Kestrel.csproj"/>
         <ProjectReference Include="..\Engine\Ioxide\GenHTTP.Engine.Ioxide.csproj"/>
 

--- a/Playground/GenHTTP.Playground.csproj
+++ b/Playground/GenHTTP.Playground.csproj
@@ -14,6 +14,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <None Include="wwwroot\**" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+
+    <ItemGroup>
 
         <ProjectReference Include="..\API\GenHTTP.Api.csproj"/>
 

--- a/Playground/Program.cs
+++ b/Playground/Program.cs
@@ -4,34 +4,53 @@ using System.Security.Cryptography.X509Certificates;
 
 using GenHTTP.Engine.InternalH3Experimental;
 
+using GenHTTP.Modules.StaticWebsites;
 using GenHTTP.Modules.IO;
-using GenHTTP.Modules.Layouting;
 
 using Microsoft.Extensions.Logging.Abstractions;
 
-//   curl -k https://localhost:8443/hello              # HTTP/1.1, over TCP
-//   curl -k --http3 https://localhost:8443/hello      # HTTP/3, over QUIC
-//   curl -k -i https://localhost:8443/hello | grep -i alt-svc
+// Serves wwwroot over HTTP/1.1 and HTTP/3 at once, so a browser can be watched deciding which to
+// use. The page reports the protocol it arrived over.
 //
-// TCP:8443 and UDP:8443 are different sockets, so both engines bind the same number.
-
+//   dotnet run -c Release --project Playground
+//   curl -k https://localhost:8443/                     # HTTP/1.1, and an Alt-Svc header
+//   snap run curl -k --http3-only https://localhost:8443/
+//
+// A browser will not speak HTTP/3 to an untrusted certificate. Chrome can be told to anyway, using
+// the SPKI hash this prints on startup:
+//
+//   google-chrome --origin-to-force-quic-on=localhost:8443 \
+//                 --ignore-certificate-errors-spki-list=<printed below> \
+//                 https://localhost:8443/
+//
+// One number, two sockets: the HTTP/1.1 host binds TCP 8443 and the HTTP/3 host binds UDP 8443.
 const ushort Port = 8443;
 
-var app = Layout.Create()
-                .Add("hello", Content.From(Resource.FromString("Hello World!")));
+// Bytes of QPACK dynamic table advertised to clients. Nonzero here on purpose: this playground
+// exists partly to find out whether a browser uses one, since curl and .NET's client do not.
+const int QpackCapacity = 4096;
+
+// Beside the binary, since wwwroot is copied to the output rather than served from the source
+// tree - a relative path would resolve against whatever directory you happened to run from.
+string root = Path.Combine(AppContext.BaseDirectory, "wwwroot");
+
+var content = StaticWebsite.From(ResourceTree.FromDirectory(root));
 
 var certificate = CreateDevelopmentCertificate();
 
-var h3 = Host.Create()
-             .Handler(app)
+Console.WriteLine($"SPKI hash: {SpkiHash(certificate)}");
+
+// HTTP/3 first, so it is listening before anything advertises it.
+var h3 = Host.Create(QpackCapacity)
+             .Handler(content)
              .Logging(NullLoggerFactory.Instance, logRequests: false)
              .Bind(IPAddress.Loopback, Port, certificate);
 
-await h3.StartAsync(); // start h3 server, non blocking
+await h3.StartAsync();
 
-// h1 internal engine
+// HTTP/1.1, advertising the endpoint above. The port has to match, and nothing checks that it does.
 await GenHTTP.Engine.Internal.Host.Create()
-             .Handler(app)
+             .Handler(content)
              .Add(AltSvc.To(Port))
              .Logging(NullLoggerFactory.Instance, logRequests: false)
              .Bind(IPAddress.Loopback, Port, certificate)
@@ -43,7 +62,7 @@ static X509Certificate2 CreateDevelopmentCertificate()
 
     var request = new CertificateRequest("CN=localhost", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
 
-    // Without a SAN nothing modern will verify this, only skip it with -k.
+    // Without a SAN nothing modern will verify this, only skip it.
     var names = new SubjectAlternativeNameBuilder();
     names.AddDnsName("localhost");
     names.AddIpAddress(IPAddress.Loopback);
@@ -54,3 +73,8 @@ static X509Certificate2 CreateDevelopmentCertificate()
     // The private key has to come back through a PFX round-trip before a TLS stack will use it.
     return X509CertificateLoader.LoadPkcs12(generated.Export(X509ContentType.Pfx), null);
 }
+
+// What Chrome's --ignore-certificate-errors-spki-list wants: base64 of the SHA-256 of the
+// certificate's public key info.
+static string SpkiHash(X509Certificate2 certificate)
+    => Convert.ToBase64String(SHA256.HashData(certificate.PublicKey.ExportSubjectPublicKeyInfo()));

--- a/Playground/Program.cs
+++ b/Playground/Program.cs
@@ -40,11 +40,15 @@ var certificate = CreateDevelopmentCertificate();
 
 Console.WriteLine($"SPKI hash: {SpkiHash(certificate)}");
 
+// IPv6Any rather than Loopback: a browser resolves "localhost" itself and prefers ::1, so an
+// IPv4-only listener never sees a packet from one. TCP masks this by falling back to IPv4, QUIC
+// does not, and the result looks like a broken HTTP/3 server rather than a bind that is too narrow.
+//
 // HTTP/3 first, so it is listening before anything advertises it.
 var h3 = Host.Create(qpackDynamicTableCapacity: QpackCapacity)
              .Handler(content)
              .Logging(NullLoggerFactory.Instance, logRequests: false)
-             .Bind(IPAddress.Loopback, Port, certificate);
+             .Bind(IPAddress.IPv6Any, Port, certificate);
 
 await h3.StartAsync();
 
@@ -53,11 +57,31 @@ await GenHTTP.Engine.Internal.Host.Create()
              .Handler(content)
              .Add(AltSvc.To(Port))
              .Logging(NullLoggerFactory.Instance, logRequests: false)
-             .Bind(IPAddress.Loopback, Port, certificate)
+             .Bind(IPAddress.IPv6Any, Port, certificate)
              .RunAsync();
 
 static X509Certificate2 CreateDevelopmentCertificate()
 {
+    // A PKCS#12 issued by a local CA that the browser already trusts. This is the only arrangement
+    // Chrome accepts: it dropped support for directly-trusted leaf certificates, so the ASP.NET
+    // development certificate below (CA:FALSE, self-signed) can never satisfy it however it is
+    // marked in the trust store. Point PLAYGROUND_CERT at a mkcert-style bundle to use one.
+    //
+    // It matters because a certificate the browser merely tolerates is not enough: an origin with
+    // certificate errors has its Alt-Svc ignored outright, so HTTP/3 stays unreachable.
+    if (Environment.GetEnvironmentVariable("PLAYGROUND_CERT") is { Length: > 0 } path && File.Exists(path))
+    {
+        return X509CertificateLoader.LoadPkcs12FromFile(path, null);
+    }
+
+    // Prefer the ASP.NET development certificate if one exists. It is the same across runs, so the
+    // SPKI hash below stays stable, and `dotnet dev-certs https --trust` is enough for Firefox and
+    // curl, which do honour a trusted leaf.
+    if (FindAspNetDevelopmentCertificate() is { } trusted)
+    {
+        return trusted;
+    }
+
     using var key = RSA.Create(2048);
 
     var request = new CertificateRequest("CN=localhost", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
@@ -72,6 +96,28 @@ static X509Certificate2 CreateDevelopmentCertificate()
 
     // The private key has to come back through a PFX round-trip before a TLS stack will use it.
     return X509CertificateLoader.LoadPkcs12(generated.Export(X509ContentType.Pfx), null);
+}
+
+/// <summary>
+/// The ASP.NET development certificate, if one is installed and still valid. Identified by the
+/// extension the tooling stamps on it rather than by its subject, which anything could claim.
+/// </summary>
+static X509Certificate2? FindAspNetDevelopmentCertificate()
+{
+    const string AspNetHttpsOid = "1.3.6.1.4.1.311.84.1.1";
+
+    using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+    store.Open(OpenFlags.ReadOnly);
+
+    // The NEWEST valid one, because that is the one `dotnet dev-certs https --trust` marks. Taking
+    // whichever the store happened to enumerate first served an older certificate that was equally
+    // valid and entirely untrusted, which a browser reports as an ordinary certificate error.
+    return store.Certificates
+                .Where(candidate => candidate.HasPrivateKey
+                                    && candidate.NotAfter > DateTime.Now
+                                    && candidate.Extensions.Any(e => e.Oid?.Value == AspNetHttpsOid))
+                .OrderByDescending(candidate => candidate.NotAfter)
+                .FirstOrDefault();
 }
 
 // What Chrome's --ignore-certificate-errors-spki-list wants: base64 of the SHA-256 of the

--- a/Playground/Program.cs
+++ b/Playground/Program.cs
@@ -13,7 +13,10 @@ using GenHTTP.Modules.Layouting;
 //
 // TCP:8443 and UDP:8443 are different sockets, so both engines bind the same number.
 
-const ushort H3Port = 8443;
+// One number, two sockets: the HTTP/1.1 host binds TCP 8443 and the HTTP/3 host binds
+// UDP 8443. They do not collide, and Alt-Svc can then advertise the same port the client is
+// already talking to.
+const ushort Port = 8443;
 
 var app = Layout.Create()
                 .Add("hello", Content.From(Resource.FromString("Hello World!")));
@@ -23,7 +26,7 @@ var certificate = CreateDevelopmentCertificate();
 // HTTP/3 first, so it is listening before anything advertises it.
 var h3 = Host.Create()
              .Handler(app)
-             .Bind(IPAddress.Loopback, H3Port, certificate);
+             .Bind(IPAddress.Loopback, Port, certificate);
 
 await h3.StartAsync();
 
@@ -31,8 +34,8 @@ await h3.StartAsync();
 // get it wrong and clients simply never upgrade.
 await GenHTTP.Engine.Internal.Host.Create()
              .Handler(app)
-             .Add(AltSvc.To(H3Port))
-             .Bind(IPAddress.Loopback, H3Port, certificate)
+             .Add(AltSvc.To(Port))
+             .Bind(IPAddress.Loopback, Port, certificate)
              .RunAsync();
 
 static X509Certificate2 CreateDevelopmentCertificate()

--- a/Playground/Program.cs
+++ b/Playground/Program.cs
@@ -15,9 +15,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 //
 // TCP:8443 and UDP:8443 are different sockets, so both engines bind the same number.
 
-// One number, two sockets: the HTTP/1.1 host binds TCP 8443 and the HTTP/3 host binds
-// UDP 8443. They do not collide, and Alt-Svc can then advertise the same port the client is
-// already talking to.
 const ushort Port = 8443;
 
 var app = Layout.Create()
@@ -25,19 +22,14 @@ var app = Layout.Create()
 
 var certificate = CreateDevelopmentCertificate();
 
-// HTTP/3 first, so it is listening before anything advertises it.
-//
-// Request logging is off on both hosts: it writes a console line per request, which is enough to
-// dominate a throughput measurement. Drop the Logging call to get it back.
 var h3 = Host.Create()
              .Handler(app)
              .Logging(NullLoggerFactory.Instance, logRequests: false)
              .Bind(IPAddress.Loopback, Port, certificate);
 
-await h3.StartAsync();
+await h3.StartAsync(); // start h3 server, non blocking
 
-// HTTP/1.1, advertising the endpoint above. The port has to match, and nothing checks that it does:
-// get it wrong and clients simply never upgrade.
+// h1 internal engine
 await GenHTTP.Engine.Internal.Host.Create()
              .Handler(app)
              .Add(AltSvc.To(Port))

--- a/Playground/Program.cs
+++ b/Playground/Program.cs
@@ -41,7 +41,7 @@ var certificate = CreateDevelopmentCertificate();
 Console.WriteLine($"SPKI hash: {SpkiHash(certificate)}");
 
 // HTTP/3 first, so it is listening before anything advertises it.
-var h3 = Host.Create(QpackCapacity)
+var h3 = Host.Create(qpackDynamicTableCapacity: QpackCapacity)
              .Handler(content)
              .Logging(NullLoggerFactory.Instance, logRequests: false)
              .Bind(IPAddress.Loopback, Port, certificate);

--- a/Playground/Program.cs
+++ b/Playground/Program.cs
@@ -1,9 +1,63 @@
-using GenHTTP.Engine.Internal;
+using System.Net;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+using GenHTTP.Engine.InternalH3Experimental;
 
 using GenHTTP.Modules.IO;
+using GenHTTP.Modules.Layouting;
 
-var app = Content.From(Resource.FromString("Hello World!"));
+// Serves one application over HTTP/1.1 and HTTP/3 at once.
+//
+//   curl -k https://localhost:8443/hello              # HTTP/1.1, over TCP
+//   curl -k --http3 https://localhost:8443/hello      # HTTP/3, over QUIC
+//   curl -k -i https://localhost:8443/hello | grep -i alt-svc
+//
+// TCP:8443 and UDP:8443 are different sockets, so both engines bind the same number.
+//
+// A browser will only reach HTTP/3 via the Alt-Svc header below, and only after it has already
+// loaded the page over TCP once. It also wants a certificate it trusts, which the self-signed one
+// here is not, so use curl --http3 to see HTTP/3 actually serve.
+//
+// QUIC needs libmsquic: shipped with the .NET runtime on Windows, `apt install libmsquic` on Linux,
+// `brew install libmsquic` on macOS.
 
-await Host.Create()
-          .Handler(app)
-          .RunAsync();
+const ushort Port = 8443;
+
+var app = Layout.Create()
+                .Add("hello", Content.From(Resource.FromString("Hello World!")));
+
+var certificate = CreateDevelopmentCertificate();
+
+// HTTP/3 first, so it is listening before anything advertises it.
+var h3 = Host.Create()
+             .Handler(app)
+             .Bind(IPAddress.Loopback, Port, certificate);
+
+await h3.StartAsync();
+
+// HTTP/1.1, advertising the endpoint above. The port has to match, and nothing checks that it does:
+// get it wrong and clients simply never upgrade.
+await GenHTTP.Engine.Internal.Host.Create()
+             .Handler(app)
+             .Add(AltSvc.To(Port))
+             .Bind(IPAddress.Loopback, Port, certificate)
+             .RunAsync();
+
+static X509Certificate2 CreateDevelopmentCertificate()
+{
+    using var key = RSA.Create(2048);
+
+    var request = new CertificateRequest("CN=localhost", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+    // Without a SAN nothing modern will verify this, only skip it with -k.
+    var names = new SubjectAlternativeNameBuilder();
+    names.AddDnsName("localhost");
+    names.AddIpAddress(IPAddress.Loopback);
+    request.CertificateExtensions.Add(names.Build());
+
+    using var generated = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1));
+
+    // The private key has to come back through a PFX round-trip before a TLS stack will use it.
+    return X509CertificateLoader.LoadPkcs12(generated.Export(X509ContentType.Pfx), null);
+}

--- a/Playground/Program.cs
+++ b/Playground/Program.cs
@@ -7,22 +7,13 @@ using GenHTTP.Engine.InternalH3Experimental;
 using GenHTTP.Modules.IO;
 using GenHTTP.Modules.Layouting;
 
-// Serves one application over HTTP/1.1 and HTTP/3 at once.
-//
 //   curl -k https://localhost:8443/hello              # HTTP/1.1, over TCP
 //   curl -k --http3 https://localhost:8443/hello      # HTTP/3, over QUIC
 //   curl -k -i https://localhost:8443/hello | grep -i alt-svc
 //
 // TCP:8443 and UDP:8443 are different sockets, so both engines bind the same number.
-//
-// A browser will only reach HTTP/3 via the Alt-Svc header below, and only after it has already
-// loaded the page over TCP once. It also wants a certificate it trusts, which the self-signed one
-// here is not, so use curl --http3 to see HTTP/3 actually serve.
-//
-// QUIC needs libmsquic: shipped with the .NET runtime on Windows, `apt install libmsquic` on Linux,
-// `brew install libmsquic` on macOS.
 
-const ushort Port = 8443;
+const ushort H3Port = 8443;
 
 var app = Layout.Create()
                 .Add("hello", Content.From(Resource.FromString("Hello World!")));
@@ -32,7 +23,7 @@ var certificate = CreateDevelopmentCertificate();
 // HTTP/3 first, so it is listening before anything advertises it.
 var h3 = Host.Create()
              .Handler(app)
-             .Bind(IPAddress.Loopback, Port, certificate);
+             .Bind(IPAddress.Loopback, H3Port, certificate);
 
 await h3.StartAsync();
 
@@ -40,8 +31,8 @@ await h3.StartAsync();
 // get it wrong and clients simply never upgrade.
 await GenHTTP.Engine.Internal.Host.Create()
              .Handler(app)
-             .Add(AltSvc.To(Port))
-             .Bind(IPAddress.Loopback, Port, certificate)
+             .Add(AltSvc.To(H3Port))
+             .Bind(IPAddress.Loopback, H3Port, certificate)
              .RunAsync();
 
 static X509Certificate2 CreateDevelopmentCertificate()

--- a/Playground/Program.cs
+++ b/Playground/Program.cs
@@ -7,6 +7,8 @@ using GenHTTP.Engine.InternalH3Experimental;
 using GenHTTP.Modules.IO;
 using GenHTTP.Modules.Layouting;
 
+using Microsoft.Extensions.Logging.Abstractions;
+
 //   curl -k https://localhost:8443/hello              # HTTP/1.1, over TCP
 //   curl -k --http3 https://localhost:8443/hello      # HTTP/3, over QUIC
 //   curl -k -i https://localhost:8443/hello | grep -i alt-svc
@@ -24,8 +26,12 @@ var app = Layout.Create()
 var certificate = CreateDevelopmentCertificate();
 
 // HTTP/3 first, so it is listening before anything advertises it.
+//
+// Request logging is off on both hosts: it writes a console line per request, which is enough to
+// dominate a throughput measurement. Drop the Logging call to get it back.
 var h3 = Host.Create()
              .Handler(app)
+             .Logging(NullLoggerFactory.Instance, logRequests: false)
              .Bind(IPAddress.Loopback, Port, certificate);
 
 await h3.StartAsync();
@@ -35,6 +41,7 @@ await h3.StartAsync();
 await GenHTTP.Engine.Internal.Host.Create()
              .Handler(app)
              .Add(AltSvc.To(Port))
+             .Logging(NullLoggerFactory.Instance, logRequests: false)
              .Bind(IPAddress.Loopback, Port, certificate)
              .RunAsync();
 

--- a/Playground/wwwroot/img/a.svg
+++ b/Playground/wwwroot/img/a.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="60"><rect width="120" height="60" fill="#2563eb"/><text x="60" y="36" text-anchor="middle" fill="#fff" font-family="sans-serif">a</text></svg>

--- a/Playground/wwwroot/img/b.svg
+++ b/Playground/wwwroot/img/b.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="60"><rect width="120" height="60" fill="#16a34a"/><text x="60" y="36" text-anchor="middle" fill="#fff" font-family="sans-serif">b</text></svg>

--- a/Playground/wwwroot/img/c.svg
+++ b/Playground/wwwroot/img/c.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="60"><rect width="120" height="60" fill="#dc2626"/><text x="60" y="36" text-anchor="middle" fill="#fff" font-family="sans-serif">c</text></svg>

--- a/Playground/wwwroot/index.html
+++ b/Playground/wwwroot/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>GenHTTP over HTTP/3</title>
+<style>
+  body { font: 16px/1.5 system-ui, sans-serif; max-width: 40rem; margin: 4rem auto; padding: 0 1rem; }
+  code { background: #f4f4f5; padding: .1rem .3rem; border-radius: .2rem; }
+  img { display: block; margin: 1rem 0; }
+</style>
+<h1>GenHTTP over HTTP/3</h1>
+<p>
+  Served by the experimental HTTP/3 engine, with HTTP/3 framing and QPACK from Glyph3 and QUIC from
+  System.Net.Quic.
+</p>
+<p>
+  The first load arrives over HTTP/1.1. The response carries an <code>Alt-Svc</code> header pointing
+  at the same port over UDP, so a reload should switch to HTTP/3. Check the Protocol column in the
+  network tab.
+</p>
+<img src="/img/a.svg" width="120" height="60" alt="">
+<img src="/img/b.svg" width="120" height="60" alt="">
+<img src="/img/c.svg" width="120" height="60" alt="">
+<p>
+  Several subresources on purpose: repeated requests on one connection are what a QPACK dynamic
+  table would compress.
+</p>
+<script src="/js/app.js"></script>

--- a/Playground/wwwroot/js/app.js
+++ b/Playground/wwwroot/js/app.js
@@ -1,0 +1,5 @@
+// Reports the protocol the browser actually used, which is the point of the page.
+const nav = performance.getEntriesByType("navigation")[0];
+const note = document.createElement("p");
+note.innerHTML = `This document arrived over <code>${nav ? nav.nextHopProtocol || "(unknown)" : "(unknown)"}</code>.`;
+document.body.appendChild(note);


### PR DESCRIPTION
First idea:

Both h1 an h3 servers, can't really merge them into one because internal engine is TCP/Socket bounded.

h3 adds a alt-svc advertisement on the h1 server.