### PR TITLE
Enable runtime-async on code generated assemblies

### DIFF
--- a/Modules/Reflection/GenHTTP.Modules.Reflection.csproj
+++ b/Modules/Reflection/GenHTTP.Modules.Reflection.csproj
@@ -18,18 +18,18 @@
         <ProjectReference Include="..\Conversion\GenHTTP.Modules.Conversion.csproj" />
         <ProjectReference Include="..\Pages\GenHTTP.Modules.Pages.csproj" />
 
-        <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
-            <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
-        </ItemGroup>
-
-        <ItemGroup Condition="'$(TargetFramework)' != 'net11.0'">
-            <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
-        </ItemGroup>
-
         <ProjectReference Include="..\..\Generators\MemoryView\GenHTTP.Generators.MemoryView.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 
     </ItemGroup>
+    
+    <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
+    </ItemGroup>
 
+    <ItemGroup Condition="'$(TargetFramework)' != 'net11.0'">
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
+    </ItemGroup>
+    
     <ItemGroup>
         <None Include="README.md" Pack="true" PackagePath="" />
     </ItemGroup>

--- a/Modules/Reflection/GenHTTP.Modules.Reflection.csproj
+++ b/Modules/Reflection/GenHTTP.Modules.Reflection.csproj
@@ -18,7 +18,13 @@
         <ProjectReference Include="..\Conversion\GenHTTP.Modules.Conversion.csproj" />
         <ProjectReference Include="..\Pages\GenHTTP.Modules.Pages.csproj" />
 
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
+        <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
+            <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
+        </ItemGroup>
+
+        <ItemGroup Condition="'$(TargetFramework)' != 'net11.0'">
+            <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
+        </ItemGroup>
 
         <ProjectReference Include="..\..\Generators\MemoryView\GenHTTP.Generators.MemoryView.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 

--- a/Modules/Reflection/Generation/DelegateProvider.cs
+++ b/Modules/Reflection/Generation/DelegateProvider.cs
@@ -4,6 +4,7 @@ using System.Runtime.Loader;
 
 using GenHTTP.Api.Content;
 using GenHTTP.Api.Protocol;
+
 using GenHTTP.Modules.IO;
 using GenHTTP.Modules.Reflection.Operations;
 using GenHTTP.Modules.Reflection.Routing;
@@ -24,6 +25,14 @@ internal static class DelegateProvider
         deterministic: false
     );
 
+    private static readonly CSharpParseOptions? ParseOptions =
+#if NET11_0_OR_GREATER
+        new CSharpParseOptions(LanguageVersion.Preview)
+            .WithFeatures([new KeyValuePair<string, string>("runtime-async", "on")]);
+#else
+        null;
+#endif
+
     private static bool _requirementsLoaded;
 
     /// <summary>
@@ -35,7 +44,7 @@ internal static class DelegateProvider
     /// <exception cref="InvalidOperationException">Thrown if the compilation failed for some reason</exception>
     internal static Func<T, Operation, IRequest, IHandler, MethodRegistry, RoutingMatch, RequestInterception, ValueTask<IResponse?>> Compile<T>(string code)
     {
-        var syntaxTree = CSharpSyntaxTree.ParseText(code);
+        var syntaxTree = CSharpSyntaxTree.ParseText(code, ParseOptions);
 
         var assemblyName = Path.GetRandomFileName();
 
@@ -88,7 +97,7 @@ internal static class DelegateProvider
             _requirementsLoaded = true;
         }
 
-        return References.Values.ToArray();
+        return [.. References.Values];
     }
 
     private static MetadataReference LoadAssembly(string fullName)

--- a/Testing/Acceptance/GenHTTP.Testing.Acceptance.csproj
+++ b/Testing/Acceptance/GenHTTP.Testing.Acceptance.csproj
@@ -55,7 +55,7 @@
         <PackageReference Include="Microsoft.OpenApi" Version="3.10.2" />
         <PackageReference Include="Microsoft.OpenApi.YamlReader" Version="3.10.2" />
 
-        <PackageReference Include="MSTest" Version="4.3.3" />
+        <PackageReference Include="MSTest" Version="4.4.0" />
 
         <PackageReference Include="NSubstitute" Version="6.2.0" />
 


### PR DESCRIPTION
Requires a new version of `Microsoft.CodeAnalysis.CSharp`, which is not available yet.